### PR TITLE
Add configurable button click duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ source files. These classes simply inherit from `Peripheral`. Specific hardware 
 should derive from one of these classes and implement the `init()` method to handle
 device setup.
 
+`Button` now also exposes `press()` and `release()` helpers that measure how long
+the button was held. The acceptable duration for a single click can be modified
+with `setClickThreshold()`, and calling `release()` returns whether the hold time
+was within this limit.
+
 ### Using Arduino Libraries
 
 If you need to include `Arduino.h` for additional functionality, the build

--- a/include/Button.hpp
+++ b/include/Button.hpp
@@ -2,11 +2,22 @@
 #define BUTTON_HPP
 
 #include "Peripheral.hpp"
+#include <chrono>
 
 class Button : public Peripheral {
 public:
     Button();
     ~Button() override;
+
+    void setClickThreshold(std::chrono::milliseconds duration);
+    std::chrono::milliseconds getClickThreshold() const;
+
+    void press();
+    bool release();
+
+private:
+    std::chrono::milliseconds clickThreshold;
+    std::chrono::steady_clock::time_point pressTime;
 };
 
 #endif // BUTTON_HPP

--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -1,4 +1,22 @@
 #include "Button.hpp"
 
-Button::Button() = default;
+Button::Button() : clickThreshold(std::chrono::milliseconds(200)) {}
 Button::~Button() = default;
+
+void Button::setClickThreshold(std::chrono::milliseconds duration) {
+    clickThreshold = duration;
+}
+
+std::chrono::milliseconds Button::getClickThreshold() const {
+    return clickThreshold;
+}
+
+void Button::press() {
+    pressTime = std::chrono::steady_clock::now();
+}
+
+bool Button::release() {
+    auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - pressTime);
+    return diff <= clickThreshold;
+}

--- a/tests/test_button.cpp
+++ b/tests/test_button.cpp
@@ -1,6 +1,8 @@
 #include "catch_amalgamated.hpp"
 #include "Button.hpp"
 #include "MemoryTracker.hpp"
+#include <chrono>
+#include <thread>
 
 class DummyButton : public Button {
 public:
@@ -14,5 +16,22 @@ TEST_CASE("Button initializes", "[button]") {
     int before = allocCount.load();
     b.init();
     REQUIRE(b.initialized);
+    REQUIRE(allocCount.load() == before);
+}
+
+TEST_CASE("Click duration threshold is configurable", "[button]") {
+    DummyButton b;
+    b.setClickThreshold(std::chrono::milliseconds(30));
+    b.press();
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    int before = allocCount.load();
+    REQUIRE(b.release());
+    REQUIRE(allocCount.load() == before);
+
+    b.setClickThreshold(std::chrono::milliseconds(10));
+    b.press();
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    before = allocCount.load();
+    REQUIRE_FALSE(b.release());
     REQUIRE(allocCount.load() == before);
 }


### PR DESCRIPTION
## Summary
- allow Button to measure press duration
- expose click threshold configuration
- document new Button press/release helpers
- test configurable click duration

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68696e93cdf8832d91338a280b03b6dc