### PR TITLE
Add lint and coverage utilities

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,17 +18,13 @@ jobs:
           python-version: '3.x'
       - name: Install PlatformIO
         run: pip install --upgrade platformio
+      - name: Install tools
+        run: sudo apt-get update && sudo apt-get install -y clang-tidy cppcheck gcovr
       - name: Build firmware
         run: platformio run
+      - name: Lint
+        run: make lint
       - name: Run unit tests
-        run: |
-          g++ -Ilib/Catch2 -Itests -Iinclude -DCATCH_AMALGAMATED_CUSTOM_MAIN -std=c++17 \
-            lib/Catch2/catch_amalgamated.cpp tests/test_main.cpp \
-            tests/MemoryTracker.cpp \
-            tests/test_module.cpp tests/test_sensor.cpp tests/test_switch.cpp \
-            tests/test_button.cpp tests/test_display.cpp tests/test_digitalpin.cpp \
-            tests/test_analogpin.cpp tests/test_oleddisplay.cpp \
-            src/Module.cpp src/Sensor.cpp src/Switch.cpp src/Button.cpp src/Display.cpp \
-            src/OledDisplay.cpp \
-            src/Pin.cpp src/DigitalPin.cpp src/AnalogPin.cpp -o test_all
-          ./test_all --reporter compact
+        run: make test
+      - name: Coverage
+        run: make coverage

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@
 .pio/
 .vscode/
 libdeps/
+*.gcno
+*.gcda
+coverage*
+test_all_cov

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,33 @@
-.PHONY: build test clean
+.PHONY: build test clean lint coverage
+
+TEST_FLAGS = -Ilib/Catch2 -Itests -Iinclude -DCATCH_AMALGAMATED_CUSTOM_MAIN -std=c++17
+TEST_SRCS = \
+    lib/Catch2/catch_amalgamated.cpp tests/test_main.cpp \
+    tests/MemoryTracker.cpp \
+    tests/test_module.cpp tests/test_sensor.cpp tests/test_switch.cpp \
+    tests/test_button.cpp tests/test_display.cpp tests/test_digitalpin.cpp \
+    tests/test_analogpin.cpp tests/test_oleddisplay.cpp \
+    src/Module.cpp src/Sensor.cpp src/Switch.cpp src/Button.cpp src/Display.cpp \
+    src/OledDisplay.cpp \
+    src/Pin.cpp src/DigitalPin.cpp src/AnalogPin.cpp
 
 build:
 	platformio run
 
 test:
-	g++ -Ilib/Catch2 -Itests -Iinclude -DCATCH_AMALGAMATED_CUSTOM_MAIN -std=c++17 \
-		lib/Catch2/catch_amalgamated.cpp tests/test_main.cpp \
-		tests/MemoryTracker.cpp \
-		tests/test_module.cpp tests/test_sensor.cpp tests/test_switch.cpp \
-		tests/test_button.cpp tests/test_display.cpp tests/test_digitalpin.cpp \
-		tests/test_analogpin.cpp tests/test_oleddisplay.cpp \
-		src/Module.cpp src/Sensor.cpp src/Switch.cpp src/Button.cpp src/Display.cpp \
-		src/OledDisplay.cpp \
-		src/Pin.cpp src/DigitalPin.cpp src/AnalogPin.cpp \
-		-o test_all
+	g++ $(TEST_FLAGS) $(TEST_SRCS) -o test_all
 	./test_all --reporter compact
+
+lint:
+	cppcheck --enable=all --inconclusive --std=c++17 --force src include tests
+
+coverage:
+	g++ $(TEST_FLAGS) --coverage $(TEST_SRCS) -o test_all_cov
+	./test_all_cov --reporter compact
+	gcovr -r . --exclude-directories=lib --exclude='.*Catch2.*' --print-summary
+	$(RM) *.gcno *.gcda test_all_cov
 
 clean:
 	platformio run -t clean
-	$(RM) test_all
+	$(RM) test_all test_all_cov
+	$(RM) *.gcno *.gcda

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ make build   # builds the firmware via PlatformIO
 make clean   # removes PlatformIO artifacts and the test binary
 ```
 
+Additional tools can check code quality and coverage. Install them with:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y clang-tidy cppcheck gcovr
+```
+
 ## Running Unit Tests
 
 Run the Catch2-based test suite with:
@@ -43,3 +50,17 @@ make test
 ```
 
 which compiles and executes the unit tests with a compact output format.
+
+## Code Quality
+
+Run static analysis with:
+
+```bash
+make lint
+```
+
+Generate a coverage report with:
+
+```bash
+make coverage
+```


### PR DESCRIPTION
## Summary
- add cppcheck-based `make lint` target and coverage target
- document required packages and new commands in README
- ignore coverage artifacts
- run new lint and coverage steps in CI

## Testing
- `make lint`
- `make coverage`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686aca852470832dbe728eca9b4c3ea4