### PR TITLE
Add clang-format check to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,12 +35,12 @@ jobs:
           ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
       - name: Install tools
         run: sudo apt-get update && sudo apt-get install -y cppcheck clang-format
-      - name: Lint
-        run: make lint
       - name: Check formatting
         run: |
           files=$(git ls-files 'src/*.cpp' 'include/*.hpp' 'tests/*.cpp' 'tests/*.hpp')
           clang-format --dry-run --Werror $files
+      - name: Lint
+        run: make lint
 
   unit-tests:
     if: github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true


### PR DESCRIPTION
## Summary
- fail sanity CI when code isn't clang-formatted

## Testing
- `make lint`
- `make test`
- `clang-format --dry-run --Werror $(git ls-files 'src/*.cpp' 'include/*.hpp' 'tests/*.cpp' 'tests/*.hpp')`

------
https://chatgpt.com/codex/tasks/task_e_686b317a307c832da021e7dafbe6db90