### PR TITLE
Add NixOS dev shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,13 @@ Generate a coverage report with:
 make coverage
 ```
 
+
+## Nix Development Shell
+
+You can create a reproducible environment using [Nix](https://nixos.org/). After installing Nix, run:
+
+```bash
+nix develop
+```
+
+This command drops you into a shell with PlatformIO, gcc and the tools used by the Makefile targets. From there, use `make build`, `make test` and the other commands as described above.

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "Slipperboard development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.platformio
+            pkgs.gcc
+            pkgs.cppcheck
+            pkgs.clang-tools
+            pkgs.gcovr
+          ];
+        };
+      });
+}


### PR DESCRIPTION
## Summary
- provide flake.nix for PlatformIO build environment
- document using `nix develop` in the README

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686b346a7a10832d83f8f09d143d97a5