### PR TITLE
Combine build and size target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,7 @@ jobs:
       - name: Install tools
         run: sudo apt-get update && sudo apt-get install -y clang-tidy cppcheck gcovr
       - name: Build firmware
-        run: platformio run
-      - name: Show firmware size
-        run: platformio run --target size
+        run: make build
 
   sanity:
     if: github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ TEST_SRCS = \
 
 build:
 	platformio run
+	platformio run --target size
 
 test:
 	g++ $(TEST_FLAGS) $(TEST_SRCS) -o test_all

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ from `app_main()`.
 Build the firmware using the Makefile:
 
 ```bash
-make build   # builds the firmware via PlatformIO
+make build   # builds the firmware via PlatformIO and shows size
 make clean   # removes PlatformIO artifacts and the test binary
 ```
 


### PR DESCRIPTION
## Summary
- show firmware size as part of `make build`
- invoke the Makefile rule from the GitHub Actions workflow
- document updated `make build` command

## Testing
- `make lint`
- `make test`
- `make coverage`


------
https://chatgpt.com/codex/tasks/task_e_686b348110dc832d8d12a29f13dc70da