### PR TITLE
Add format check command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,7 @@ jobs:
       - name: Install tools
         run: sudo apt-get update && sudo apt-get install -y cppcheck clang-format
       - name: Check formatting
-        run: |
-          files=$(git ls-files 'src/*.cpp' 'include/*.hpp' 'tests/*.cpp' 'tests/*.hpp')
-          clang-format --dry-run --Werror $files
+        run: make check-format
       - name: Lint
         run: make lint
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean lint coverage format
+.PHONY: build test clean lint coverage format check-format
 
 TEST_FLAGS = -Ilib/Catch2 -Itests -Iinclude -DCATCH_AMALGAMATED_CUSTOM_MAIN -std=c++17
 TEST_SRCS = \
@@ -34,8 +34,12 @@ coverage:
 	gcovr -r . --exclude-directories=lib --exclude='.*Catch2.*' --print-summary --fail-under-line=100
 	$(RM) *.gcno *.gcda test_all_cov
 
+
 format:
 	clang-format -i $(FMT_FILES)
+
+check-format:
+	clang-format --dry-run --Werror $(FMT_FILES)
 
 clean:
 	platformio run -t clean

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Automatically apply the project's clang-format style with:
 make format
 ```
 
+Check formatting without modifying files:
+
+```bash
+make check-format
+```
+
 ## Nix Development Shell
 
 You can create a reproducible environment using [Nix](https://nixos.org/). After installing Nix, run:


### PR DESCRIPTION
## Summary
- add `check-format` to Makefile for validating clang-format
- run `make check-format` during CI sanity job
- document the new check command in README

## Testing
- `make lint`
- `make check-format`
- `make test`
- `make coverage`


------
https://chatgpt.com/codex/tasks/task_e_686b590e5908832da641788352e06759