### PR TITLE
Ensure tidy exits on warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ lint:
 	src include
 TIDY_FILES := $(shell git ls-files 'src/*.cpp' | grep -v 'src/main.cpp')
 tidy:
-	clang-tidy -quiet $(TIDY_FILES) -- -std=c++17 -Iinclude > clang-tidy.log
+	clang-tidy $(TIDY_FILES) -- -std=c++17 -Iinclude > clang-tidy.log 2>&1
 	cat clang-tidy.log
 	! grep -E "(warning:|error:)" clang-tidy.log
 	rm clang-tidy.log


### PR DESCRIPTION
## Summary
- make `tidy` fail whenever `clang-tidy` emits warnings or errors

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686c0f27c8d4832da25f8a00d6d5504f