### PR TITLE
Improve out-of-bounds handling

### DIFF
--- a/src/OledDisplay.cpp
+++ b/src/OledDisplay.cpp
@@ -36,9 +36,8 @@ void OledDisplay::readBytes(Point pos, unsigned char *out, std::size_t length) c
         if (px < 0 || px >= width || py < 0 || py >= height)
         {
             out[i] = 0;
-        } else
-        {
-            out[i] = buffer[py * width + px];
+            continue;
         }
+        out[i] = buffer[py * width + px];
     }
 }


### PR DESCRIPTION
## Summary
- improve OledDisplay::readBytes loop by continuing early

## Testing
- `make format`
- `make check-format`
- `make lint`
- `make tidy`
- `make test`
- `make build` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_686c15f83fe0832d9311419d977f73ea