### PR TITLE
Add code conventions check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y cppcheck clang-format clang-tidy
       - name: Check formatting
         run: make check-format
+      - name: Conventions
+        run: make conventions
       - name: Lint
         run: make lint
       - name: Static analysis

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean lint tidy coverage format check-format
+.PHONY: build test clean lint tidy coverage format check-format conventions
 
 TEST_FLAGS = -Ilib/Catch2 -Itests -Iinclude -DCATCH_AMALGAMATED_CUSTOM_MAIN -std=c++17
 TEST_SRCS = \
@@ -47,6 +47,12 @@ format:
 
 check-format:
 	clang-format --dry-run --Werror $(FMT_FILES)
+
+conventions: check-format
+	@if grep -nP '\t' $(FMT_FILES); then \
+	echo "Tabs detected. Use spaces only."; \
+	exit 1; \
+	fi
 
 clean:
 	platformio run -t clean

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ Check formatting without modifying files:
 make check-format
 ```
 
+## Code Conventions
+
+Verify that open braces start on a new line and tabs are absent:
+
+```bash
+make conventions
+```
+
 ## Nix Development Shell
 
 You can create a reproducible environment using [Nix](https://nixos.org/). After installing Nix, run:


### PR DESCRIPTION
## Summary
- add `conventions` make target for checking tabs and brace placement via clang-format
- integrate conventions check in CI
- document the new command in the README

## Testing
- `make test`
- `make lint`
- `make tidy`
- `make check-format`
- `make conventions`


------
https://chatgpt.com/codex/tasks/task_e_686c171374bc832dbb367619054e6b35