### PR TITLE
Drop circular display support

### DIFF
--- a/include/Display.hpp
+++ b/include/Display.hpp
@@ -19,23 +19,17 @@ class Display : public Peripheral
     public:
     // Construct a rectangular display
     explicit Display(Dimensions dims);
-    // Construct a circular display
-    explicit Display(int radius);
     ~Display() override;
 
     int getWidth() const;
     int getHeight() const;
-    int getRadius() const;
-    bool isCircular() const;
 
     // Draw a series of bytes at the given coordinate
     virtual void drawBytes(Point pos, const unsigned char *data, std::size_t length) = 0;
 
     protected:
-    bool circular;
     int width;
     int height;
-    int radius;
 };
 
 #endif // DISPLAY_HPP

--- a/src/Display.cpp
+++ b/src/Display.cpp
@@ -1,10 +1,6 @@
 #include "Display.hpp"
 
-Display::Display(Dimensions dims) : circular(false), width(dims.width), height(dims.height), radius(0)
-{
-}
-
-Display::Display(int radius) : circular(true), width(0), height(0), radius(radius)
+Display::Display(Dimensions dims) : width(dims.width), height(dims.height)
 {
 }
 
@@ -17,12 +13,4 @@ int Display::getWidth() const
 int Display::getHeight() const
 {
     return height;
-}
-int Display::getRadius() const
-{
-    return radius;
-}
-bool Display::isCircular() const
-{
-    return circular;
 }

--- a/tests/test_display.cpp
+++ b/tests/test_display.cpp
@@ -8,9 +8,6 @@ class DummyDisplay : public Display
     DummyDisplay() : Display({10, 10})
     {
     }
-    explicit DummyDisplay(int radius) : Display(radius)
-    {
-    }
     bool initialized = false;
     void init() override
     {
@@ -38,15 +35,4 @@ TEST_CASE("Display stores dimensions", "[display]")
     DummyDisplay d;
     REQUIRE(d.getWidth() == 10);
     REQUIRE(d.getHeight() == 10);
-    bool circ = d.isCircular();
-    REQUIRE_FALSE(circ);
-}
-
-TEST_CASE("Circular display stores radius", "[display]")
-{
-    DummyDisplay d(5);
-    REQUIRE(d.isCircular());
-    REQUIRE(d.getRadius() == 5);
-    REQUIRE(d.getWidth() == 0);
-    REQUIRE(d.getHeight() == 0);
 }


### PR DESCRIPTION
## Summary
- remove circular display constructor and helpers
- clean up display tests

## Testing
- `make format`
- `make check-format`
- `make test`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_686c26f76fb0832da05860e37c22fe7b