### PR TITLE
Integrate oled display with lvgl

### DIFF
--- a/include/AdafruitDisplayStub.hpp
+++ b/include/AdafruitDisplayStub.hpp
@@ -1,0 +1,17 @@
+#ifndef ADAFRUIT_DISPLAY_STUB_HPP
+#define ADAFRUIT_DISPLAY_STUB_HPP
+
+#include <cstdint>
+
+class AdafruitDisplayStub {
+public:
+    AdafruitDisplayStub(int16_t width, int16_t height) {
+        static_cast<void>(width);
+        static_cast<void>(height);
+    }
+    bool begin() { return true; }
+    void drawPixel(int16_t, int16_t, uint8_t) {}
+    void display() {}
+};
+
+#endif // ADAFRUIT_DISPLAY_STUB_HPP

--- a/include/LvglStub.hpp
+++ b/include/LvglStub.hpp
@@ -1,0 +1,9 @@
+#ifndef LVGL_STUB_HPP
+#define LVGL_STUB_HPP
+
+#include <cstdint>
+
+inline void lv_init() {}
+inline void lv_draw_pixel(int16_t, int16_t, uint8_t) {}
+
+#endif // LVGL_STUB_HPP

--- a/include/OledDisplay.hpp
+++ b/include/OledDisplay.hpp
@@ -1,6 +1,7 @@
 #ifndef OLED_DISPLAY_HPP
 #define OLED_DISPLAY_HPP
 
+#include "AdafruitDisplayStub.hpp"
 #include "Display.hpp"
 #include <vector>
 
@@ -19,6 +20,7 @@ class OledDisplay : public Display
     private:
     std::vector<unsigned char> buffer;
     bool initialized = false;
+    AdafruitDisplayStub hw;
 };
 
 #endif // OLED_DISPLAY_HPP

--- a/src/OledDisplay.cpp
+++ b/src/OledDisplay.cpp
@@ -1,13 +1,16 @@
 #include "OledDisplay.hpp"
+#include "LvglStub.hpp"
 
-OledDisplay::OledDisplay() : Display({128, 64}), buffer(static_cast<std::size_t>(128) * 64, 0)
+OledDisplay::OledDisplay() : Display({128, 64}), buffer(static_cast<std::size_t>(128) * 64, 0), hw(128, 64)
 {
 }
 
 void OledDisplay::init()
 {
-    // In a real implementation this would initialize the Adafruit and lvgl
-    // libraries. Here we simply mark the display as ready.
+    // Initialize the display hardware and lvgl. In this stub implementation the
+    // calls are no-ops but mimic the real libraries.
+    lv_init();
+    hw.begin();
     initialized = true;
 }
 
@@ -23,8 +26,11 @@ void OledDisplay::drawBytes(Point pos, const unsigned char *data, std::size_t le
         if (px >= 0 && px < width && py >= 0 && py < height)
         {
             buffer[py * width + px] = data[i];
+            lv_draw_pixel(static_cast<int16_t>(px), static_cast<int16_t>(py), data[i]);
+            hw.drawPixel(static_cast<int16_t>(px), static_cast<int16_t>(py), data[i]);
         }
     }
+    hw.display();
 }
 
 void OledDisplay::readBytes(Point pos, unsigned char *out, std::size_t length) const


### PR DESCRIPTION
## Summary
- add stub implementations for lvgl and Adafruit display
- update `OledDisplay` to initialize lvgl and the Adafruit display
- send pixels through the stub libraries while keeping the test buffer

## Testing
- `make cpplint`
- `make test`
- `make coverage` *(fails: gcovr missing)*
- `make lint` *(fails: cppcheck missing)*
- `make tidy`
- `make build` *(fails: platformio missing)*
- `make precommit` *(fails: platformio missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c7b845dfc832da7ae8a66a73a9416