### PR TITLE
Remove ESP_PLATFORM guards

### DIFF
--- a/include/OledDisplay.hpp
+++ b/include/OledDisplay.hpp
@@ -4,11 +4,14 @@
 #include "Display.hpp"
 #include <vector>
 
+#include <Adafruit_SSD1306.h>
+#include <lvgl.h>
+
 class OledDisplay : public Display
 {
     public:
     OledDisplay();
-    ~OledDisplay() override = default;
+    ~OledDisplay() override;
 
     void init() override;
     void drawBytes(Point pos, const unsigned char *data, std::size_t length) override;
@@ -19,6 +22,12 @@ class OledDisplay : public Display
     private:
     std::vector<unsigned char> buffer;
     bool initialized = false;
+
+    static void flushCallback(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color);
+    static Adafruit_SSD1306 display;
+    static lv_disp_draw_buf_t drawBuf;
+    static lv_disp_drv_t dispDrv;
+    static lv_color_t *lvBuffer;
 };
 
 #endif // OLED_DISPLAY_HPP

--- a/src/OledDisplay.cpp
+++ b/src/OledDisplay.cpp
@@ -1,19 +1,41 @@
 #include "OledDisplay.hpp"
 
+#include <Wire.h>
+
 OledDisplay::OledDisplay() : Display({128, 64}), buffer(static_cast<std::size_t>(128) * 64, 0)
 {
 }
 
+OledDisplay::~OledDisplay()
+{
+    if (lvBuffer != nullptr)
+    {
+        free(lvBuffer);
+        lvBuffer = nullptr;
+    }
+}
+
 void OledDisplay::init()
 {
-    // In a real implementation this would initialize the Adafruit and lvgl
-    // libraries. Here we simply mark the display as ready.
+    if (!display.begin(SSD1306_SWITCHCAPVCC, 0x3C))
+    {
+        return;
+    }
+    display.clearDisplay();
+    lv_init();
+    lvBuffer = static_cast<lv_color_t *>(malloc(static_cast<size_t>(width) * height * sizeof(lv_color_t)));
+    lv_disp_draw_buf_init(&drawBuf, lvBuffer, nullptr, width * height);
+    lv_disp_drv_init(&dispDrv);
+    dispDrv.draw_buf = &drawBuf;
+    dispDrv.hor_res = width;
+    dispDrv.ver_res = height;
+    dispDrv.flush_cb = flushCallback;
+    lv_disp_drv_register(&dispDrv);
     initialized = true;
 }
 
 void OledDisplay::drawBytes(Point pos, const unsigned char *data, std::size_t length)
 {
-    // Simple buffer write emulation. Each byte represents a pixel.
     if (!initialized)
         return;
     for (std::size_t i = 0; i < length; ++i)
@@ -23,8 +45,10 @@ void OledDisplay::drawBytes(Point pos, const unsigned char *data, std::size_t le
         if (px >= 0 && px < width && py >= 0 && py < height)
         {
             buffer[py * width + px] = data[i];
+            display.drawPixel(px, py, data[i] ? WHITE : BLACK);
         }
     }
+    display.display();
 }
 
 void OledDisplay::readBytes(Point pos, unsigned char *out, std::size_t length) const
@@ -40,4 +64,22 @@ void OledDisplay::readBytes(Point pos, unsigned char *out, std::size_t length) c
         }
         out[i] = buffer[py * width + px];
     }
+}
+
+Adafruit_SSD1306 OledDisplay::display(128, 64, &Wire, -1);
+lv_disp_draw_buf_t OledDisplay::drawBuf;
+lv_disp_drv_t OledDisplay::dispDrv;
+lv_color_t *OledDisplay::lvBuffer = nullptr;
+
+void OledDisplay::flushCallback(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color)
+{
+    for (int y = area->y1; y <= area->y2; ++y)
+    {
+        for (int x = area->x1; x <= area->x2; ++x, ++color)
+        {
+            display.drawPixel(x, y, color->full ? WHITE : BLACK);
+        }
+    }
+    display.display();
+    lv_disp_flush_ready(drv);
 }


### PR DESCRIPTION
## Summary
- remove ESP_PLATFORM checks from OledDisplay implementation
- always include Adafruit and LVGL headers

## Testing
- `make precommit` *(fails: platformio not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d247e128c832d844c8a68abc5b822