### PR TITLE
Add OLED display to Wokwi

### DIFF
--- a/diagram.json
+++ b/diagram.json
@@ -9,11 +9,21 @@
       "top": 0,
       "left": 0,
       "attrs": { "fullBoot": "1" }
+    },
+    {
+      "type": "wokwi-ssd1306",
+      "id": "oled",
+      "top": -60,
+      "left": 140
     }
   ],
   "connections": [
     ["esp:TX0", "$serialMonitor:RX", "", []],
-    ["esp:RX0", "$serialMonitor:TX", "", []]
+    ["esp:RX0", "$serialMonitor:TX", "", []],
+    ["esp:21", "oled:SDA", "green", []],
+    ["esp:22", "oled:SCL", "green", []],
+    ["esp:3V3", "oled:VCC", "red", []],
+    ["esp:GND.1", "oled:GND", "black", []]
   ],
   "serialMonitor": {
     "display": "terminal"


### PR DESCRIPTION
## Summary
- update `diagram.json` to include a 0.96" SSD1306 OLED display and connect it to the ESP32 board

## Testing
- `make wokwi-sanity`
- `make build` *(fails: HTTPClientError)*
- `make precommit` *(fails: platformio HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_687150fb5908832da45e554767230218