### PR TITLE
Add devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        clang-format \
+        clang-tidy \
+        cppcheck \
+        gcovr \
+        git \
+        nodejs npm \
+        python3 python3-pip \
+    && pip3 install --no-cache-dir platformio cpplint \
+    && npm install -g @wokwi/cli \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+    "name": "Slipperboard",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "features": {},
+    "postCreateCommand": "make build || true",
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "C_Cpp.clang_format_style": "file"
+            }
+        }
+    }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,4 +66,15 @@ jobs:
       - name: Coverage
         run: make coverage
 
+  devcontainer:
+    if: github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      - uses: devcontainers/ci@v0.3
+        with:
+          runCmd: make precommit
+
 

--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,6 @@ emulate: build
 
 wokwi-sanity:
 	python3 scripts/wokwi_sanity.py
+
+devcontainer:
+	devcontainer up --workspace-folder .

--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ nix develop
 
 This drops you into a shell with PlatformIO, gcc and the Makefile tools available.
 
+## Dev Container
+
+To work inside a fully configured VS Code dev container, run:
+
+```bash
+make devcontainer
+```
+
+This command starts the container defined in `.devcontainer` and attaches to it.
+
 ## Emulator
 
 You can also run the firmware inside the [Wokwi](https://wokwi.com/) emulator to


### PR DESCRIPTION
## Summary
- create devcontainer for VS Code
- provide make target to launch dev container
- run all checks using the devcontainer in CI

## Testing
- `make build` *(fails: missing PlatformIO packages)*
- `make precommit` *(fails: HTTPClientError downloading PlatformIO packages)*

------
https://chatgpt.com/codex/tasks/task_e_6871acc1e73c832d96d61a59c150fd42