### PR TITLE
Reorganize Makefile and build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,26 +26,6 @@ jobs:
       - name: Wokwi config sanity
         run: make wokwi-sanity
 
-  sanity:
-    if: github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
-      - name: Install tools
-        run: |
-          sudo apt-get update && sudo apt-get install -y cppcheck clang-format clang-tidy
-          pip install --user cpplint
-      - name: Check formatting
-        run: make check-format
-      - name: Lint
-        run: make lint
-      - name: Cpplint
-        run: make cpplint
-      - name: Static analysis
-        run: make tidy
-
   unit-tests:
     if: github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
@@ -66,4 +46,22 @@ jobs:
       - name: Coverage
         run: make coverage
 
-
+  sanity:
+    if: github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      - name: Install tools
+        run: |
+          sudo apt-get update && sudo apt-get install -y cppcheck clang-format clang-tidy
+          pip install --user cpplint
+      - name: Check formatting
+        run: make check-format
+      - name: Lint
+        run: make lint
+      - name: Cpplint
+        run: make cpplint
+      - name: Static analysis
+        run: make tidy

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean lint tidy cpplint coverage format check-format precommit emulate wokwi-sanity
+.PHONY: build clean test coverage lint cpplint tidy format check-format precommit emulate wokwi-sanity
 
 TEST_FLAGS = -Ilib/Catch2 -Itests -Iinclude -DCATCH_AMALGAMATED_CUSTOM_MAIN -std=c++17
 TEST_SRCS = \
@@ -13,38 +13,16 @@ TEST_SRCS = \
 
 FMT_FILES := $(shell git ls-files 'src/*.cpp' 'include/*.hpp' 'tests/*.cpp' 'tests/*.hpp')
 CPPLINT_FILES := $(FMT_FILES)
+TIDY_FILES := $(shell git ls-files 'src/*.cpp' | grep -v 'src/main.cpp')
 
 build:
 	platformio run
 	platformio run --target size
 
-test:
-	g++ $(TEST_FLAGS) $(TEST_SRCS) -o test_all
-	./test_all --reporter console --success
-	
-lint:
-	cppcheck --enable=all --inconclusive --std=c++17 --force --max-configs=1 --inline-suppr \
-	--suppress=missingIncludeSystem \
-	--suppress=missingInclude --suppress=unmatchedSuppression --suppress=unusedFunction \
-	--error-exitcode=1 -Iinclude -Isrc \
-	src include
-
-cpplint:
-	cpplint $(CPPLINT_FILES) || (echo "cpplint style violations found" && exit 1)
-TIDY_FILES := $(shell git ls-files 'src/*.cpp' | grep -v 'src/main.cpp')
-tidy:
-	clang-tidy $(TIDY_FILES) -- -std=c++17 -Iinclude > clang-tidy.log 2>&1
-	cat clang-tidy.log
-	! grep -E "(warning:|error:)" clang-tidy.log
-	rm clang-tidy.log
-
-	
-coverage:
-	g++ $(TEST_FLAGS) --coverage $(TEST_SRCS) -o test_all_cov
-	./test_all_cov --reporter console --success
-	gcovr -r . --exclude-directories=lib --exclude='.*Catch2.*' --print-summary --fail-under-line=100
-	$(RM) *.gcno *.gcda test_all_cov
-
+clean:
+	platformio run -t clean
+	$(RM) test_all test_all_cov
+	$(RM) *.gcno *.gcda
 
 format:
 	clang-format -i $(FMT_FILES)
@@ -52,10 +30,31 @@ format:
 check-format:
 	clang-format --dry-run --Werror $(FMT_FILES)
 
-clean:
-	platformio run -t clean
-	$(RM) test_all test_all_cov
-	$(RM) *.gcno *.gcda
+cpplint:
+	cpplint $(CPPLINT_FILES) || (echo "cpplint style violations found" && exit 1)
+
+lint:
+	cppcheck --enable=all --inconclusive --std=c++17 --force --max-configs=1 --inline-suppr \
+	--suppress=missingIncludeSystem \
+	--suppress=missingInclude --suppress=unmatchedSuppression --suppress=unusedFunction \
+	--error-exitcode=1 -Iinclude -Isrc \
+	src include
+
+tidy:
+	clang-tidy $(TIDY_FILES) -- -std=c++17 -Iinclude > clang-tidy.log 2>&1
+	cat clang-tidy.log
+	! grep -E "(warning:|error:)" clang-tidy.log
+	rm clang-tidy.log
+
+test:
+	g++ $(TEST_FLAGS) $(TEST_SRCS) -o test_all
+	./test_all --reporter console --success
+
+coverage:
+	g++ $(TEST_FLAGS) --coverage $(TEST_SRCS) -o test_all_cov
+	./test_all_cov --reporter console --success
+	gcovr -r . --exclude-directories=lib --exclude='.*Catch2.*' --print-summary --fail-under-line=100
+	$(RM) *.gcno *.gcda test_all_cov
 
 precommit:
 	$(MAKE) build


### PR DESCRIPTION
## Summary
- reorder sections in the Makefile so related actions sit together
- shuffle jobs in `.github/workflows/build.yml` so build, unit-tests and sanity are grouped logically

## Testing
- `make precommit` *(fails: PlatformIO registry blocked)*
- `make build` *(fails: PlatformIO registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6872df512b40832db5ca8c5114470afc