### PR TITLE
Integrate LVGL and SSD1306 with OledDisplay

### DIFF
--- a/include/OledDisplay.hpp
+++ b/include/OledDisplay.hpp
@@ -4,6 +4,13 @@
 #include "Display.hpp"
 #include <vector>
 
+#ifdef ESP_PLATFORM
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
+#include <Wire.h>
+#include <lvgl.h>
+#endif
+
 class OledDisplay : public Display
 {
     public:
@@ -19,6 +26,9 @@ class OledDisplay : public Display
     private:
     std::vector<unsigned char> buffer;
     bool initialized = false;
+#ifdef ESP_PLATFORM
+    Adafruit_SSD1306 oled{128, 64, &Wire, -1};
+#endif
 };
 
 #endif // OLED_DISPLAY_HPP

--- a/src/OledDisplay.cpp
+++ b/src/OledDisplay.cpp
@@ -1,13 +1,51 @@
 #include "OledDisplay.hpp"
 
+#ifdef ESP_PLATFORM
+static Adafruit_SSD1306 *oled_ptr = nullptr;
+
+static void lvgl_flush_cb(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
+{
+    if (!oled_ptr)
+        return;
+    for (int y = area->y1; y <= area->y2; ++y)
+    {
+        for (int x = area->x1; x <= area->x2; ++x, ++color_p)
+        {
+            oled_ptr->drawPixel(x, y, color_p->full ? WHITE : BLACK);
+        }
+    }
+    oled_ptr->display();
+    lv_disp_flush_ready(drv);
+}
+#endif
+
 OledDisplay::OledDisplay() : Display({128, 64}), buffer(static_cast<std::size_t>(128) * 64, 0)
 {
 }
 
 void OledDisplay::init()
 {
-    // In a real implementation this would initialize the Adafruit and lvgl
-    // libraries. Here we simply mark the display as ready.
+#ifdef ESP_PLATFORM
+    lv_init();
+    oled.begin(SSD1306_SWITCHCAPVCC, 0x3C);
+    oled.clearDisplay();
+    oled.display();
+
+    static lv_disp_draw_buf_t draw_buf;
+    static lv_color_t lv_buf[128 * 64 / 8];
+    lv_disp_draw_buf_init(&draw_buf, lv_buf, nullptr, 128 * 64);
+
+    static lv_disp_drv_t disp_drv;
+    lv_disp_drv_init(&disp_drv);
+    disp_drv.hor_res = 128;
+    disp_drv.ver_res = 64;
+    disp_drv.flush_cb = lvgl_flush_cb;
+    disp_drv.draw_buf = &draw_buf;
+    lv_disp_drv_register(&disp_drv);
+
+    oled_ptr = &oled;
+#endif
+    // Mark the display as ready for host tests as well
     initialized = true;
 }
 
@@ -23,8 +61,14 @@ void OledDisplay::drawBytes(Point pos, const unsigned char *data, std::size_t le
         if (px >= 0 && px < width && py >= 0 && py < height)
         {
             buffer[py * width + px] = data[i];
+#ifdef ESP_PLATFORM
+            oled.drawPixel(px, py, data[i] ? WHITE : BLACK);
+#endif
         }
     }
+#ifdef ESP_PLATFORM
+    oled.display();
+#endif
 }
 
 void OledDisplay::readBytes(Point pos, unsigned char *out, std::size_t length) const


### PR DESCRIPTION
## Summary
- integrate LVGL and Adafruit SSD1306 libraries when building on ESP32
- hook up display driver initialization and pixel flushing
- update `drawBytes` to also write to the hardware display

## Testing
- `make test`
- `make cpplint`
- `make check-format`
- `make tidy`
- `make coverage`
- `make precommit` *(fails: platformio cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687315cb75cc832d99ed20c0b3b43a84