### PR TITLE
Update AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,36 +1,9 @@
 # AGENTS.md
 
-...
+## Precommit Agent
 
-## Agent: Precommit Agent
+All contributions must pass the `make precommit` gate. This command formats
+sources, builds the firmware, runs tests, and performs linting when available.
+It applies to everyone—humans, Codex, CI jobs, and bots.
 
-- **Type**: Universal validation gate
-- **Purpose**: Enforce code quality and consistency before integration
-- **Command**: `make precommit`
-- **Scope**: **Applies to all contributors and systems**, including:
-  - Human developers
-  - Codex (LLM assistant)
-  - CI jobs (pre-merge verification)
-  - Any automated tool or bot producing a pull request
-- **Checks Run**:
-  - Code formatting (`make format-check`)
-  - Compilation (`make build`)
-  - Unit tests (`make test`)
-  - Static analysis or linting (if configured)
-- **Policy**:
-  - If `make precommit` fails, the code **must not** be submitted for review
-  - All agents are expected to self-verify via this mechanism before initiating a PR or push
-  - CI will redundantly enforce it to ensure compliance
-- **Interacts With**:
-  - Makefile (delegates to individual targets)
-  - All other agents (enforcement and feedback)
-
-...
-
-## Contributor Policy
-
-> **All contributors — including AI agents, humans, CI scripts, and bots — must run:**
-
-```bash
-make precommit
-```
+Fix any failures before opening a pull request or pushing changes.


### PR DESCRIPTION
## Summary
- replace AGENTS.md with details about the Precommit Agent and contributor policy

## Testing
- `make precommit` *(fails: PlatformIO can't download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68749359aaa4832d8dc835984b762620