### PR TITLE
Add GitHub release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
   workflow_dispatch:
+  push:
+    branches:
+      - master
 
 jobs:
   build:
@@ -65,3 +68,25 @@ jobs:
           pip install --user cpplint
       - name: Run ${{ matrix.task }}
         run: make ${{ matrix.task }}
+
+  release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: [build, unit-tests, sanity]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install PlatformIO
+        run: pip install --upgrade platformio
+      - name: Build firmware
+        run: make build
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: v${{ github.run_number }}
+          name: Release v${{ github.run_number }}
+          artifacts: .pio/build/esp32dev/firmware.bin
+          body: Automated release for commit ${{ github.sha }}.


### PR DESCRIPTION
## Summary
- trigger CI on master pushes
- add a release job that publishes firmware artifacts

## Testing
- `make precommit` *(fails: PlatformIO package install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687541c20f88832db0eb06caae91f5cc