### PR TITLE
Add Pin constructor tests

### DIFF
--- a/tests/test_analogpin.cpp
+++ b/tests/test_analogpin.cpp
@@ -32,3 +32,13 @@ TEST_CASE("AnalogPin dynamic alloc", "[analogpin]")
     delete pin;
     REQUIRE(allocCount.load() == before);
 }
+
+TEST_CASE("AnalogPin constructor sets hardware pin mode", "[analogpin]")
+{
+    pinModes[31] = -1;
+    AnalogPin pin(31, OUTPUT);
+    REQUIRE(pinModes[31] == OUTPUT);
+    pinModes[30] = -1;
+    AnalogPin inputPin(30, INPUT);
+    REQUIRE(pinModes[30] == INPUT);
+}

--- a/tests/test_digitalpin.cpp
+++ b/tests/test_digitalpin.cpp
@@ -36,3 +36,13 @@ TEST_CASE("DigitalPin read respects mode", "[digitalpin]")
     DigitalPin outputPin(8, OUTPUT, false);
     REQUIRE_FALSE(outputPin.read());
 }
+
+TEST_CASE("DigitalPin constructor sets hardware pin mode", "[digitalpin]")
+{
+    pinModes[9] = -1;
+    DigitalPin pin(9, OUTPUT);
+    REQUIRE(pinModes[9] == OUTPUT);
+    pinModes[10] = -1;
+    DigitalPin inputPin(10, INPUT);
+    REQUIRE(pinModes[10] == INPUT);
+}

--- a/tests/test_pwmpin.cpp
+++ b/tests/test_pwmpin.cpp
@@ -14,3 +14,13 @@ TEST_CASE("PWMPin read/write", "[pwmpin]")
     REQUIRE(pin.read() == 20);
     REQUIRE(allocCount.load() == before);
 }
+
+TEST_CASE("PWMPin constructor sets hardware pin mode", "[pwmpin]")
+{
+    pinModes[11] = -1;
+    PWMPin pin(11, OUTPUT);
+    REQUIRE(pinModes[11] == OUTPUT);
+    pinModes[12] = -1;
+    PWMPin inputPin(12, INPUT);
+    REQUIRE(pinModes[12] == INPUT);
+}


### PR DESCRIPTION
## Summary
- ensure derived pins set pin mode by invoking the Pin constructor

## Testing
- `make test`
- `make coverage`
- `make precommit` *(fails: PlatformIO downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68782bc579e4832d815da0582cf84b45