### PR TITLE
Add uuid to Peripheral

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ TEST_FLAGS = -Ilib/Catch2 -Itests -Iinclude -DCATCH_AMALGAMATED_CUSTOM_MAIN -std
 TEST_SRCS = \
 	lib/Catch2/catch_amalgamated.cpp tests/test_main.cpp \
 	tests/MemoryTracker.cpp \
-	tests/test_module.cpp tests/test_sensor.cpp tests/test_switch.cpp \
+        tests/test_module.cpp tests/test_sensor.cpp tests/test_switch.cpp tests/test_peripheral.cpp \
         tests/Arduino.cpp \
         tests/test_button.cpp tests/test_display.cpp tests/test_digitalpin.cpp \
         tests/test_analogpin.cpp tests/test_pwmpin.cpp \
         tests/test_memory.cpp \
-        src/Module.cpp src/Sensor.cpp src/Switch.cpp src/Button.cpp src/Display.cpp \
+        src/Module.cpp src/Sensor.cpp src/Switch.cpp src/Button.cpp src/Display.cpp src/Peripheral.cpp \
         src/Pin.cpp src/DigitalPin.cpp src/AnalogPin.cpp src/PWMPin.cpp
 
 FMT_FILES := $(shell git ls-files 'src/*.cpp' 'include/*.hpp' 'tests/*.cpp' 'tests/*.hpp')

--- a/docs/HARDWARE_ABSTRACTION_LAYER.md
+++ b/docs/HARDWARE_ABSTRACTION_LAYER.md
@@ -1,7 +1,7 @@
 # Hardware Abstraction Layer
 
 `include/Peripheral.hpp` defines a lightweight base class named `Peripheral` that exposes
-only a virtual destructor. Generic device categories are provided in separate headers
+an optional UUID string via `setUuid()`/`getUuid()` in addition to a virtual destructor. Generic device categories are provided in separate headers
 (`Module.hpp`, `Sensor.hpp`, `Switch.hpp`, `Button.hpp`, and `Display.hpp`) with matching
 source files. These classes simply inherit from `Peripheral`. Specific hardware drivers
 should derive from one of these classes and perform any required setup in the constructor.

--- a/include/Peripheral.hpp
+++ b/include/Peripheral.hpp
@@ -1,6 +1,8 @@
 #ifndef PERIPHERAL_HPP
 #define PERIPHERAL_HPP
 
+#include <string>
+
 // Base abstract class for all hardware types. It exposes only the
 // lifecycle hook required by the framework.
 class Peripheral
@@ -8,6 +10,12 @@ class Peripheral
     public:
     Peripheral() = default;
     virtual ~Peripheral() = default;
+
+    void setUuid(const std::string& id);
+    const std::string& getUuid() const;
+
+    private:
+    std::string uuid;
 };
 
 #endif // PERIPHERAL_HPP

--- a/src/Peripheral.cpp
+++ b/src/Peripheral.cpp
@@ -1,0 +1,12 @@
+#include "Peripheral.hpp"
+#include <string>
+
+void Peripheral::setUuid(const std::string& id)
+{
+    uuid = id;
+}
+
+const std::string& Peripheral::getUuid() const
+{
+    return uuid;
+}

--- a/tests/test_peripheral.cpp
+++ b/tests/test_peripheral.cpp
@@ -1,0 +1,12 @@
+#include <string>
+#include "MemoryTracker.hpp"
+#include "Peripheral.hpp"
+#include "catch_amalgamated.hpp"
+
+TEST_CASE("Peripheral uuid can be set and retrieved", "[peripheral]")
+{
+    Peripheral p;
+    REQUIRE(p.getUuid().empty());
+    p.setUuid("abc-123");
+    REQUIRE(p.getUuid() == std::string("abc-123"));
+}


### PR DESCRIPTION
## Summary
- extend `Peripheral` with a `uuid` member and accessors
- document the new member in the HAL overview
- compile and run tests for the new functionality

## Testing
- `make test`
- `make coverage`
- `make lint`
- `make tidy`
- `make cpplint`


------
https://chatgpt.com/codex/tasks/task_e_68788552207c832d9fe162d13587086c