### PR TITLE
Add build artifacts directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ libdeps/
 coverage*
 test_all_cov
 test_all
+build/
+firmware.bin
+firmware.elf

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,14 @@ FMT_FILES := $(shell git ls-files 'src/*.cpp' 'include/*.hpp' 'tests/*.cpp' 'tes
 CPPLINT_FILES := $(FMT_FILES)
 TIDY_FILES := $(shell git ls-files 'src/*.cpp' | grep -v 'src/main.cpp')
 
+BUILD_DIR ?= build
+
 build:
 	platformio run
 	platformio run --target size
+	mkdir -p $(BUILD_DIR)
+	cp .pio/build/esp32dev/firmware.bin $(BUILD_DIR)/firmware.bin
+	cp .pio/build/esp32dev/firmware.elf $(BUILD_DIR)/firmware.elf
 
 clean:
 	platformio run -t clean

--- a/README.md
+++ b/README.md
@@ -70,6 +70,26 @@ Run the full suite of formatting, linting, and tests before submitting a change:
 make precommit
 ```
 
+## Vagrant Environment
+
+If you don't have the required toolchain installed locally, you can build the
+project inside a Linux VM using Vagrant. After installing
+[Vagrant](https://www.vagrantup.com/), start the virtual machine and run the
+build:
+
+```bash
+vagrant up      # provisions an Ubuntu box with all dependencies
+vagrant ssh
+cd /vagrant && make build
+```
+
+The compiled firmware appears in the `build/` directory at the project root,
+which is shared with the host. You can then flash the `.bin` file from your
+host system without leaving the VM.
+
+Run `make precommit` in the VM to execute the full suite of formatting, linting
+and tests.
+
 ## Emulator
 
 You can run the firmware inside the [Wokwi](https://wokwi.com/) emulator to test

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,15 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/jammy64"
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 2048
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get update
+    sudo apt-get install -y build-essential clang clang-format clang-tidy cppcheck nodejs python3 python3-pip git
+    sudo pip3 install platformio cpplint gcovr
+  SHELL
+end

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,3 +13,4 @@ build_flags =
 
 [platformio]
 test_dir = tests
+build_dir = build


### PR DESCRIPTION
## Summary
- copy built firmware to `build/`
- ignore `build/` artifacts in git
- document where Vagrant builds place firmware
- configure PlatformIO to use the `build` directory

## Testing
- `make precommit` *(fails: PlatformIO package download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68792fc56888832d8e8a18de8b3e36a2