### PR TITLE
Add drawBytes functionality

### DIFF
--- a/include/Display.hpp
+++ b/include/Display.hpp
@@ -26,7 +26,7 @@ class Display : public Peripheral
     int getWidth() const;
     int getHeight() const;
 
-    // Draw a series of bytes at the given coordinate
+    // Draw a series of bytes at the given coordinate using the underlying display
     virtual void drawBytes(Point pos, const unsigned char* data, std::size_t length) = 0;
 
     protected:

--- a/src/Display.cpp
+++ b/src/Display.cpp
@@ -1,7 +1,20 @@
 #include "Display.hpp"
 
+#ifdef ARDUINO
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
+#include <lvgl.h>
+
+static Adafruit_SSD1306 oled(128, 64, &Wire);
+#endif
+
 Display::Display(Dimensions dims) : width(dims.width), height(dims.height)
 {
+#ifdef ARDUINO
+    oled.begin(SSD1306_SWITCHCAPVCC, 0x3C);
+    oled.clearDisplay();
+    lv_init();
+#endif
 }
 
 Display::~Display() = default;
@@ -13,4 +26,20 @@ int Display::getWidth() const
 int Display::getHeight() const
 {
     return height;
+}
+
+void Display::drawBytes(Point pos, const unsigned char* data, std::size_t length)
+{
+#ifdef ARDUINO
+    oled.setCursor(pos.x, pos.y);
+    for (std::size_t i = 0; i < length; ++i)
+    {
+        oled.write(data[i]);
+    }
+    oled.display();
+#else
+    (void) pos;
+    (void) data;
+    (void) length;
+#endif
 }

--- a/tests/test_display.cpp
+++ b/tests/test_display.cpp
@@ -10,8 +10,9 @@ class DummyDisplay : public Display
         initialized = true;
     }
     bool initialized = false;
-    void drawBytes(Point, const unsigned char*, std::size_t) override
+    void drawBytes(Point pos, const unsigned char* data, std::size_t length) override
     {
+        Display::drawBytes(pos, data, length);
     }
 };
 
@@ -22,6 +23,15 @@ TEST_CASE("Display initializes", "[display]")
     int before = allocCount.load();
     // call the virtual function to ensure coverage
     d.drawBytes({0, 0}, nullptr, 0);
+    REQUIRE(allocCount.load() == before);
+}
+
+TEST_CASE("Display drawBytes default", "[display]")
+{
+    DummyDisplay d;
+    unsigned char msg[] = "test";
+    int before = allocCount.load();
+    d.drawBytes({0, 0}, msg, sizeof(msg) - 1);
     REQUIRE(allocCount.load() == before);
 }
 


### PR DESCRIPTION
## Summary
- use `drawBytes` instead of `writeBytes` for displaying characters
- update tests for `drawBytes`

## Testing
- `make test`
- `make precommit` *(fails: PlatformIO registry unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687936c28904832da47981951a69120d