### PR TITLE
Update CI to skip docs-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
       - id: filter
         uses: dorny/paths-filter@v2
         with:
+          # NOTE: Keep this list in sync with repository structure.
+          # Add new paths here when introducing additional code directories or
+          # build-related files.
           filters: |
             code:
               - 'src/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,32 @@ on:
       - master
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - id: filter
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'include/**'
+              - 'lib/**'
+              - 'tests/**'
+              - 'scripts/**'
+              - 'platformio.ini'
+              - 'Makefile'
+              - 'diagram.json'
+              - 'wokwi.toml'
+
   build:
-    if: github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true
+    needs: changes
+    if: (needs.changes.outputs.code == 'true') && (github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -30,7 +54,8 @@ jobs:
         run: make wokwi-sanity
 
   unit-tests:
-    if: github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true
+    needs: changes
+    if: (needs.changes.outputs.code == 'true') && (github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -52,7 +77,8 @@ jobs:
         run: make ${{ matrix.task }}
 
   sanity:
-    if: github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true
+    needs: changes
+    if: (needs.changes.outputs.code == 'true') && (github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Run the full suite of formatting, linting, and tests before submitting a change:
 make precommit
 ```
 
+The CI workflow skips builds when a pull request only modifies documentation.
+Maintain the list of code paths in `.github/workflows/build.yml` whenever new
+directories or build files are added to ensure the filter remains accurate.
+
 ## Emulator
 
 You can run the firmware inside the [Wokwi](https://wokwi.com/) emulator to test

--- a/README.md
+++ b/README.md
@@ -78,10 +78,6 @@ Run the full suite of formatting, linting, and tests before submitting a change:
 make precommit
 ```
 
-The CI workflow skips builds when a pull request only modifies documentation.
-Maintain the list of code paths in `.github/workflows/build.yml` whenever new
-directories or build files are added to ensure the filter remains accurate.
-
 ## Emulator
 
 You can run the firmware inside the [Wokwi](https://wokwi.com/) emulator to test


### PR DESCRIPTION
## Summary
- avoid running CI for documentation-only updates by detecting code changes

## Testing
- `make precommit` *(fails: HTTPClientError when installing PlatformIO)*

------
https://chatgpt.com/codex/tasks/task_e_687a95c22888832d8f65a7ccf6a980cf