### PR TITLE
Add devcontainer build check

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,29 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    clang \
+    clang-format \
+    clang-tidy \
+    cppcheck \
+    python3 \
+    python3-pip \
+    gcovr \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js from NodeSource to ensure npm is available
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install cpplint and PlatformIO
+# Ubuntu images enable PEP 668 which prevents system-wide pip installs.
+# --break-system-packages allows installing to the base environment.
+RUN pip3 install --break-system-packages --no-cache-dir cpplint platformio
+
+# Install Wokwi CLI so the emulator can run inside the container
+RUN curl -L https://wokwi.com/ci/install.sh | sh
+
+ENV PATH="/root/.local/bin:${PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+    "name": "firmware-dev",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+    "workspaceFolder": "/workspace",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools",
+                "ms-python.python",
+                "platformio.platformio-ide"
+            ]
+        }
+    }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,10 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       markdown: ${{ steps.filter.outputs.markdown }}
       makefile: ${{ steps.filter.outputs.makefile }}
+      dockerfiles: ${{ steps.filter.outputs.dockerfiles }}
       markdown_files: ${{ steps.filter.outputs.markdown_files }}
       makefile_files: ${{ steps.filter.outputs.makefile_files }}
+      dockerfile_files: ${{ steps.filter.outputs.dockerfile_files }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -42,6 +44,8 @@ jobs:
               - '**/*.md'
             makefile:
               - 'Makefile'
+            dockerfiles:
+              - '**/*Dockerfile'
 
   build:
     needs: changes
@@ -89,12 +93,12 @@ jobs:
 
   sanity:
     needs: changes
-    if: ((needs.changes.outputs.code == 'true') || (needs.changes.outputs.markdown == 'true') || (needs.changes.outputs.makefile == 'true')) && (github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true)
+    if: ((needs.changes.outputs.code == 'true') || (needs.changes.outputs.markdown == 'true') || (needs.changes.outputs.makefile == 'true') || (needs.changes.outputs.dockerfiles == 'true')) && (github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        task: [check-format, lint, cpplint, tidy, markdown-lint, makefile-lint]
+        task: [check-format, lint, cpplint, tidy, markdown-lint, makefile-lint, dockerfile-lint]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -121,8 +125,32 @@ jobs:
             else
               echo "No Makefile changes" && exit 0
             fi
+          elif [ "${{ matrix.task }}" = "dockerfile-lint" ]; then
+            if [ "${{ needs.changes.outputs.dockerfiles }}" = "true" ]; then
+              make dockerfile-lint
+            else
+              echo "No Dockerfile changes" && exit 0
+            fi
           else
             make ${{ matrix.task }}
           fi
 
+
+  healthcheck:
+    needs: changes
+    if: github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        task: [devcontainer]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      - name: Run ${{ matrix.task }}
+        run: |
+          if [ "${{ matrix.task }}" = "devcontainer" ]; then
+            make devcontainer-test
+          fi
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,19 @@ This project is a template for building a Flipper Zero–compatible firmware for
 ## Development Setup
 
 1. Install the [PlatformIO CLI](https://platformio.org/install).
-2. (Optional) Install the Wokwi CLI with `npm install -g @wokwi/cli` to run the emulator.
+2. (Optional) Install the Wokwi CLI with `curl -L https://wokwi.com/ci/install.sh | sh` to run the emulator.
 3. Clone this repository and run `make build` to compile the firmware.
+
+## Dev Container
+
+This repository includes a [dev container](https://containers.dev/) configuration
+for VS Code. Open the project in VS Code and choose **Reopen in Container** to
+get a fully configured environment with PlatformIO, Wokwi CLI, and all required
+tools. You can also launch the container from the command line with
+`make env`. Any build output in the container appears in the repository directory
+on the host. The CI workflow runs a **healthcheck** job that builds this
+container and executes `make build` within it to verify the environment stays
+healthy.
 
 ## Directory Layout
 
@@ -63,6 +74,7 @@ make check-format  # [CI]
 make lint          # [CI]
 make cpplint       # [CI]
 make tidy          # [CI]
+make dockerfile-lint  # [CI]
 make coverage      # [CI]
 ```
 
@@ -78,11 +90,14 @@ Run the full suite of formatting, linting, and tests before submitting a change:
 make precommit
 ```
 
+This command also runs `make devcontainer-test` to ensure the dev container
+remains functional by building the firmware inside it.
+
 ## Emulator
 
 You can run the firmware inside the [Wokwi](https://wokwi.com/) emulator to test
 changes without hardware. First install the Wokwi CLI (for example with
-`npm install -g @wokwi/cli`), build the project, and launch the emulator:
+`curl -L https://wokwi.com/ci/install.sh | sh`), build the project, and launch the emulator:
 
 ```bash
 make build   # [CI]

--- a/scripts/dockerfile_lint.py
+++ b/scripts/dockerfile_lint.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Simple Dockerfile linter."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def lint_dockerfile(path: Path) -> list[str]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception as exc:
+        return [f"{path}: unable to read: {exc}"]
+
+    lines = text.splitlines()
+    errors: list[str] = []
+
+    # Check that the first non-comment line starts with FROM
+    for line in lines:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            if not stripped.upper().startswith("FROM "):
+                errors.append(f"{path}: first instruction should be FROM")
+            break
+
+    for idx, line in enumerate(lines, start=1):
+        if line.rstrip() != line:
+            errors.append(f"{path}:{idx}: trailing whitespace")
+        if "\t" in line:
+            errors.append(f"{path}:{idx}: tab character found")
+
+    if not text.endswith("\n"):
+        errors.append(f"{path}: missing newline at end of file")
+
+    return errors
+
+
+def main(paths: list[str]) -> int:
+    """Lint the given Dockerfiles. Return 0 if no issues are found."""
+    if not paths:
+        # Nothing to lint
+        return 0
+
+    files = [Path(p) for p in paths]
+    all_errors: list[str] = []
+    for f in files:
+        if not f.exists():
+            continue
+        all_errors.extend(lint_dockerfile(f))
+    if all_errors:
+        for err in all_errors:
+            print(err)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/markdown_lint.py
+++ b/scripts/markdown_lint.py
@@ -56,7 +56,8 @@ def check_file(path: Path) -> list[str]:
 def main(paths: list[str]) -> int:
     all_errors: list[str] = []
     files = [Path(p) for p in paths] if paths else list(Path('.').rglob('*.md'))
-    for f in files:
+    filtered = [f for f in files if '.pio' not in f.parts]
+    for f in filtered:
         all_errors.extend(check_file(f))
     if all_errors:
         for err in all_errors:


### PR DESCRIPTION
## Summary
- run `make build` in `devcontainer-test`
- clarify in README that the healthcheck only builds the firmware
- note that `make devcontainer-test` builds the firmware inside the container

## Testing
- `make precommit` *(fails: PlatformIO not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687ac07023bc832da753281c741c5dc9