### PR TITLE
Add note about running precommit in dev container

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ make precommit
 ```
 
 This command also runs `make devcontainer-test` to ensure the dev container
-remains functional by building the firmware inside it.
+remains functional by building the firmware inside it. When working inside the
+dev container, simply run `make precommit` from the container's shell—the
+environment already contains all the required tools.
 
 ## Emulator
 


### PR DESCRIPTION
## Summary
- mention that `make precommit` can be run from inside the dev container

## Testing
- `make precommit` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_687aef5d31fc832d87d3e25c1b01a565