### PR TITLE
Add env target for dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,13 @@ jobs:
           if os.environ['MAKEFILE'] == 'true':
               if "makefile-lint" not in tasks:
                   tasks.append("makefile-lint")
+          if (
+              os.environ['FIRMWARE'] == 'true'
+              or os.environ['MAKEFILE'] == 'true'
+              or os.environ['WORKFLOW'] == 'true'
+          ):
+              if "env" not in tasks:
+                  tasks.append("env")
           print(f"matrix={json.dumps(tasks)}", file=open(os.environ['GITHUB_OUTPUT'], 'a'))
           EOF
         env:
@@ -136,6 +143,8 @@ jobs:
         run: |
           if [ "${{ matrix.task }}" = "markdown-lint" ]; then
             make markdown-lint FILES="${{ needs.changes.outputs.markdown_files }}"
+          elif [ "${{ matrix.task }}" = "env" ]; then
+            make env && make build
           else
             make ${{ matrix.task }}
           fi

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean test coverage lint cpplint tidy format check-format precommit emulate wokwi-sanity markdown-lint makefile-lint
+.PHONY: build clean test coverage lint cpplint tidy format check-format precommit emulate wokwi-sanity markdown-lint makefile-lint env
 
 TEST_FLAGS = -Ilib/Catch2 -Itests -Iinclude -DCATCH_AMALGAMATED_CUSTOM_MAIN -std=c++17 -Wall -Wextra -Werror
 TEST_SRCS = \
@@ -84,3 +84,6 @@ emulate: build
 wokwi-sanity:
 	python3 scripts/wokwi_sanity.py
 
+env:
+	./scripts/setup_env.sh
+	

--- a/Makefile
+++ b/Makefile
@@ -86,4 +86,4 @@ wokwi-sanity:
 
 env:
 	./scripts/setup_env.sh
-	
+

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ This project is a template for building a Flipper Zero–compatible firmware for
 
 1. Install the [PlatformIO CLI](https://platformio.org/install).
 2. (Optional) Install the Wokwi CLI with `curl -L https://wokwi.com/ci/install.sh | sh` to run the emulator.
-3. Clone this repository and run `make env` to install dependencies
-   via `scripts/setup_env.sh`, then execute `make build` to compile
-   the firmware.
+3. Clone this repository and run `make build` to compile the firmware.
 
 ## Directory Layout
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This project is a template for building a Flipper Zero–compatible firmware for
 
 1. Install the [PlatformIO CLI](https://platformio.org/install).
 2. (Optional) Install the Wokwi CLI with `curl -L https://wokwi.com/ci/install.sh | sh` to run the emulator.
-3. Clone this repository and run `make build` to compile the firmware.
+3. Clone this repository and run `make env` to install dependencies
+   via `scripts/setup_env.sh`, then execute `make build` to compile
+   the firmware.
 
 ## Directory Layout
 

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Setup development environment dependencies for Slipperboard
 # Installs tools via apt or brew depending on OS
-set -e
+set -euo pipefail
 
 case "$(uname)" in
     Linux*)

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Setup development environment dependencies for Slipperboard
+# Installs tools via apt or brew depending on OS
+set -e
+
+case "$(uname)" in
+    Linux*)
+        if command -v apt-get >/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y python3-pip clang-format clang-tidy cppcheck gcovr
+        else
+            echo "apt-get not found. Unsupported Linux distribution." >&2
+            exit 1
+        fi
+        ;;
+    Darwin*)
+        if command -v brew >/dev/null; then
+            brew update
+            brew install clang-format clang-tidy cppcheck gcovr
+        else
+            echo "Homebrew not found. Please install Homebrew." >&2
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Unsupported platform" >&2
+        exit 1
+        ;;
+esac
+
+pip3 install --user --upgrade platformio cpplint


### PR DESCRIPTION
## Summary
- install toolchain prerequisites via `scripts/setup_env.sh`
- call the setup script from `make env`
- document the env script in README

## Testing
- `make env`
- `make precommit` *(fails: platform packages blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687bdc3511a4832db9f991688fa67eab