### PR TITLE
Install git hooks via env

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+msg_file="$1"
+first_line="$(head -n1 "$msg_file" | tr -d '\r')"
+
+if [[ ! "$first_line" =~ ^(HOTFIX:|FIX:|FEATURE:|ISSUE#[0-9]+:) ]]; then
+    echo "Error: commit message must start with one of: HOTFIX:, FIX:, FEATURE:, ISSUE#<number>:" >&2
+    exit 1
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+exec make precommit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,16 @@ jobs:
           MAKEFILE: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && 'true' || steps.filter.outputs.makefile }}
           WORKFLOW: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && 'true' || steps.filter.outputs.workflow }}
 
+  commit-message-check:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Validate commit messages
+        run: scripts/check_commit_prefix.py "${{ github.event.pull_request.base.sha }}"
+
   # Build the firmware
   build:
     needs: changes  # Wait for path filtering

--- a/Makefile
+++ b/Makefile
@@ -86,4 +86,5 @@ wokwi-sanity:
 
 env:
 	./scripts/setup_env.sh
+	./scripts/install_hooks.sh
 

--- a/scripts/check_commit_prefix.py
+++ b/scripts/check_commit_prefix.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Validate commit message prefixes."""
+import re
+import subprocess
+import sys
+
+PREFIX_RE = re.compile(r"^(HOTFIX:|FIX:|FEATURE:|ISSUE#[0-9]+:)")
+
+
+def main(base: str) -> int:
+    try:
+        log = subprocess.check_output([
+            "git",
+            "log",
+            f"{base}..HEAD",
+            "--format=%s",
+        ], text=True)
+    except subprocess.CalledProcessError as exc:
+        print(f"error: unable to read git log: {exc}", file=sys.stderr)
+        return 1
+
+    bad = False
+    for line in log.splitlines():
+        line = line.strip()
+        if not PREFIX_RE.match(line):
+            print(f"Invalid commit message prefix: {line}", file=sys.stderr)
+            bad = True
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: check_commit_prefix.py <base_sha>", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(main(sys.argv[1]))

--- a/scripts/check_commit_prefix.py
+++ b/scripts/check_commit_prefix.py
@@ -23,6 +23,7 @@ def main(base: str) -> int:
     bad = False
     for line in log.splitlines():
         line = line.strip()
+        print(line)
         if not PREFIX_RE.match(line):
             print(f"Invalid commit message prefix: {line}", file=sys.stderr)
             bad = True

--- a/scripts/check_commit_prefix.py
+++ b/scripts/check_commit_prefix.py
@@ -14,6 +14,7 @@ def main(base: str) -> int:
             "log",
             f"{base}..HEAD",
             "--format=%s",
+            "--no-merges",
         ], text=True)
     except subprocess.CalledProcessError as exc:
         print(f"error: unable to read git log: {exc}", file=sys.stderr)

--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Configure git to use the repository's githooks
+set -euo pipefail
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+current="$(git config --get core.hooksPath || echo '')"
+if [[ "$current" != ".githooks" ]]; then
+    git config core.hooksPath .githooks
+fi
+
+printf "Git hooks installed at %s/.githooks\n" "$repo_root"


### PR DESCRIPTION
## Summary
- call `scripts/install_hooks.sh` from `make env`
- drop README documentation about githooks
- enforce commit message prefixes via `commit-msg` hook
- validate commit messages during the PR workflow
- make hook installation idempotent

## Testing
- `make env`
- `make precommit` *(fails: PlatformIO registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687c69c8347c832daff25ab74c182c62