### PR TITLE
Switch to uv package manager

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,8 +112,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'  # Latest Python 3
+      - name: Install uv
+        run: curl -Ls https://astral.sh/uv/install.sh | bash
       - name: Install PlatformIO
-        run: pip install --upgrade platformio  # Install the build tool
+        run: uv tool install platformio  # Install the build tool
       - name: Install tools
         run: sudo apt-get update && sudo apt-get install -y clang-tidy cppcheck gcovr  # Lint and coverage helpers
       - name: Build firmware
@@ -139,8 +141,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+      - name: Install uv
+        run: curl -Ls https://astral.sh/uv/install.sh | bash
       - name: Install PlatformIO
-        run: pip install --upgrade platformio  # Install the build tool
+        run: uv tool install platformio  # Install the build tool
       - name: Install tools
         run: sudo apt-get update && sudo apt-get install -y gcovr  # Coverage reporter
       - name: Run ${{ matrix.task }}
@@ -167,7 +171,7 @@ jobs:
       - name: Install tools
         run: |  # Install linting tools for sanity checks
           sudo apt-get update && sudo apt-get install -y cppcheck clang-format clang-tidy  # Linting tools
-          pip install --user cpplint  # Additional style checker
+          uv tool install cpplint  # Additional style checker
       - name: Run ${{ matrix.task }}
         run: |  # Execute the requested sanity task
           if [ "${{ matrix.task }}" = "markdown-lint" ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,9 @@ jobs:
         with:
           python-version: '3.x'  # Latest Python 3
       - name: Install uv
-        run: curl -Ls https://astral.sh/uv/install.sh | bash
+        run: |
+          curl -Ls https://astral.sh/uv/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Install PlatformIO
         run: uv tool install platformio  # Install the build tool
       - name: Install tools
@@ -142,7 +144,9 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install uv
-        run: curl -Ls https://astral.sh/uv/install.sh | bash
+        run: |
+          curl -Ls https://astral.sh/uv/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Install PlatformIO
         run: uv tool install platformio  # Install the build tool
       - name: Install tools
@@ -168,6 +172,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+      - name: Install uv
+        run: |
+          curl -Ls https://astral.sh/uv/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Install tools
         run: |  # Install linting tools for sanity checks
           sudo apt-get update && sudo apt-get install -y cppcheck clang-format clang-tidy  # Linting tools

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -7,7 +7,7 @@ case "$(uname)" in
     Linux*)
         if command -v apt-get >/dev/null; then
             sudo apt-get update
-            sudo apt-get install -y python3-pip clang-format clang-tidy cppcheck gcovr
+            sudo apt-get install -y curl clang-format clang-tidy cppcheck gcovr
         else
             echo "apt-get not found. Unsupported Linux distribution." >&2
             exit 1
@@ -19,4 +19,6 @@ case "$(uname)" in
         ;;
 esac
 
-pip3 install --user --upgrade platformio cpplint
+curl -Ls https://astral.sh/uv/install.sh | bash
+uv tool install --force platformio
+uv tool install --force cpplint

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -20,5 +20,6 @@ case "$(uname)" in
 esac
 
 curl -Ls https://astral.sh/uv/install.sh | bash
+source "$HOME/.local/bin/env"
 uv tool install --force platformio
 uv tool install --force cpplint


### PR DESCRIPTION
## Summary
- replace pip and pip3 with uv across setup scripts and CI workflow
- install uv-based tools

## Testing
- `make env`
- `make precommit`

------
https://chatgpt.com/codex/tasks/task_e_687d3652d738832da4a9b25c9394f9dc