### PR TITLE
Switch to uv package manager

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,10 +112,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'  # Latest Python 3
+      - name: Install uv
+        run: bash scripts/install_uv.sh
       - name: Install PlatformIO
-        run: pip install --upgrade platformio  # Install the build tool
+        run: bash scripts/install_platformio.sh
       - name: Install tools
-        run: sudo apt-get update && sudo apt-get install -y clang-tidy cppcheck gcovr  # Lint and coverage helpers
+        run: bash scripts/install_apt_packages.sh clang-tidy cppcheck gcovr  # Lint and coverage helpers
       - name: Build firmware
         run: make build  # Compile the code
       - name: Wokwi config sanity
@@ -139,10 +141,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+      - name: Install uv
+        run: bash scripts/install_uv.sh
       - name: Install PlatformIO
-        run: pip install --upgrade platformio  # Install the build tool
+        run: bash scripts/install_platformio.sh
       - name: Install tools
-        run: sudo apt-get update && sudo apt-get install -y gcovr  # Coverage reporter
+        run: bash scripts/install_apt_packages.sh gcovr  # Coverage reporter
       - name: Run ${{ matrix.task }}
         run: make ${{ matrix.task }}  # Execute the selected target
 
@@ -164,10 +168,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+      - name: Install uv
+        run: bash scripts/install_uv.sh
       - name: Install tools
         run: |  # Install linting tools for sanity checks
-          sudo apt-get update && sudo apt-get install -y cppcheck clang-format clang-tidy  # Linting tools
-          pip install --user cpplint  # Additional style checker
+          bash scripts/install_apt_packages.sh cppcheck clang-format clang-tidy
+          bash scripts/install_cpplint.sh
       - name: Run ${{ matrix.task }}
         run: |  # Execute the requested sanity task
           if [ "${{ matrix.task }}" = "markdown-lint" ]; then

--- a/scripts/install_apt_packages.sh
+++ b/scripts/install_apt_packages.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v apt-get >/dev/null; then
+    echo "apt-get not found" >&2
+    exit 1
+fi
+
+sudo apt-get update
+sudo apt-get install -y "$@"

--- a/scripts/install_cpplint.sh
+++ b/scripts/install_cpplint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+uv tool install --force cpplint

--- a/scripts/install_platformio.sh
+++ b/scripts/install_platformio.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+uv tool install --force platformio

--- a/scripts/install_uv.sh
+++ b/scripts/install_uv.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+curl -Ls https://astral.sh/uv/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+    echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+fi

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,17 +1,12 @@
 #!/usr/bin/env bash
 # Setup development environment dependencies for Slipperboard
-# Installs tools via apt on Linux
 set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
 
 case "$(uname)" in
     Linux*)
-        if command -v apt-get >/dev/null; then
-            sudo apt-get update
-            sudo apt-get install -y python3-pip clang-format clang-tidy cppcheck gcovr
-        else
-            echo "apt-get not found. Unsupported Linux distribution." >&2
-            exit 1
-        fi
+        "$script_dir/install_apt_packages.sh" curl clang-format clang-tidy cppcheck gcovr
         ;;
     *)
         echo "Unsupported platform" >&2
@@ -19,4 +14,6 @@ case "$(uname)" in
         ;;
 esac
 
-pip3 install --user --upgrade platformio cpplint
+"$script_dir/install_uv.sh"
+"$script_dir/install_platformio.sh"
+"$script_dir/install_cpplint.sh"


### PR DESCRIPTION
## Summary
- replace pip and pip3 with uv across setup scripts and CI workflow
- ensure `$HOME/.local/bin` is added to PATH so `uv` is found
- remove sourcing missing `env` script after uv install
- export `PATH` for uv immediately in CI jobs
- split environment scripts to avoid duplication

## Testing
- `make env`
- `make precommit`


------
https://chatgpt.com/codex/tasks/task_e_687d3652d738832da4a9b25c9394f9dc