### PR TITLE
Optimize CI speed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 # Workflow name displayed in GitHub Actions
 name: CI
+# Cancel previous runs on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 # Only run tasks for files that changed to save time
 
 # Events that trigger this workflow
@@ -112,6 +116,15 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'  # Latest Python 3
+      - name: Cache PlatformIO
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.platformio
+            ~/.local
+          key: ${{ runner.os }}-pio-${{ hashFiles('platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pio-
       - name: Install uv
         run: bash scripts/install_uv.sh
       - name: Install PlatformIO
@@ -141,6 +154,15 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+      - name: Cache PlatformIO
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.platformio
+            ~/.local
+          key: ${{ runner.os }}-pio-${{ hashFiles('platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pio-
       - name: Install uv
         run: bash scripts/install_uv.sh
       - name: Install PlatformIO
@@ -168,6 +190,15 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+      - name: Cache PlatformIO
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.platformio
+            ~/.local
+          key: ${{ runner.os }}-pio-${{ hashFiles('platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pio-
       - name: Install uv
         run: bash scripts/install_uv.sh
       - name: Install tools

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,6 @@ check-format:
 cpplint:
 	cpplint $(CPPLINT_FILES) || (echo "cpplint style violations found" && exit 1)
 
-# Use --force to check all preprocessor configurations.
-# --max-configs suppresses cppcheck's "too many #ifdef" warnings.
 lint:
 	cppcheck --enable=all --inconclusive --std=c++17 --force --max-configs=2 --inline-suppr \
 	--suppress=missingIncludeSystem \

--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ Run the full suite of formatting, linting, and tests before submitting a change:
 make precommit
 ```
 
+## Continuous Integration
+
+The GitHub Actions workflow caches tool installations across jobs and
+terminates older runs of the same branch. The `install_apt_packages.sh` and
+`install_uv.sh` scripts skip downloads when tools are already present to avoid
+unnecessary network traffic.
+
 
 ## Emulator
 

--- a/README.md
+++ b/README.md
@@ -78,14 +78,6 @@ Run the full suite of formatting, linting, and tests before submitting a change:
 make precommit
 ```
 
-## Continuous Integration
-
-The GitHub Actions workflow caches tool installations across jobs and
-terminates older runs of the same branch. The `install_apt_packages.sh` and
-`install_uv.sh` scripts skip downloads when tools are already present to avoid
-unnecessary network traffic.
-
-
 ## Emulator
 
 You can run the firmware inside the [Wokwi](https://wokwi.com/) emulator to test

--- a/scripts/install_apt_packages.sh
+++ b/scripts/install_apt_packages.sh
@@ -6,5 +6,14 @@ if ! command -v apt-get >/dev/null; then
     exit 1
 fi
 
-sudo apt-get update
-sudo apt-get install -y "$@"
+missing=()
+for pkg in "$@"; do
+    if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+        missing+=("$pkg")
+    fi
+done
+
+if [ ${#missing[@]} -gt 0 ]; then
+    sudo apt-get update
+    sudo apt-get install -y --no-install-recommends "${missing[@]}"
+fi

--- a/scripts/install_uv.sh
+++ b/scripts/install_uv.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-curl -Ls https://astral.sh/uv/install.sh | bash
+if ! command -v uv >/dev/null 2>&1; then
+    curl -Ls https://astral.sh/uv/install.sh | bash
+else
+    echo "uv already installed"
+fi
 export PATH="$HOME/.local/bin:$PATH"
 
 if [[ -n "${GITHUB_PATH:-}" ]]; then


### PR DESCRIPTION
## Summary
- reuse dependencies between workflow runs using `actions/cache`
- avoid unnecessary `apt` operations
- skip `uv` installation when already present
- cancel previous runs with a concurrency group
- remove outdated cppcheck comment from Makefile

## Testing
- `make env`
- `make test`
- `make build` *(fails: HTTPClientError)*
- `make precommit` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_687d47c5ae88832db78a1f9156609e16