### PR TITLE
Remove install scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,8 +114,8 @@ jobs:
           python-version: '3.x'  # Latest Python 3
       - name: Install uv
         run: bash scripts/install_uv.sh
-      - name: Install PlatformIO
-        run: bash scripts/install_platformio.sh
+      - name: Install Python packages
+        run: uv pip install --system -r requirements.txt
       - name: Install tools
         run: bash scripts/install_apt_packages.sh clang-tidy cppcheck gcovr  # Lint and coverage helpers
       - name: Build firmware
@@ -143,8 +143,8 @@ jobs:
           python-version: '3.x'
       - name: Install uv
         run: bash scripts/install_uv.sh
-      - name: Install PlatformIO
-        run: bash scripts/install_platformio.sh
+      - name: Install Python packages
+        run: uv pip install --system -r requirements.txt
       - name: Install tools
         run: bash scripts/install_apt_packages.sh gcovr  # Coverage reporter
       - name: Run ${{ matrix.task }}
@@ -173,7 +173,7 @@ jobs:
       - name: Install tools
         run: |  # Install linting tools for sanity checks
           bash scripts/install_apt_packages.sh cppcheck clang-format clang-tidy
-          bash scripts/install_cpplint.sh
+          uv pip install --system -r requirements.txt
       - name: Run ${{ matrix.task }}
         run: |  # Execute the requested sanity task
           if [ "${{ matrix.task }}" = "markdown-lint" ]; then

--- a/README.md
+++ b/README.md
@@ -8,11 +8,9 @@ This project is a template for building a Flipper Zero–compatible firmware for
 
 ## Development Setup
 
-1. Clone this repository.
-2. Run `make env` to install the required toolchain and Python packages from
-   `requirements.txt`.
-3. (Optional) Install the Wokwi CLI with `curl -L https://wokwi.com/ci/install.sh | sh` to run the emulator.
-4. Run `make build` to compile the firmware.
+1. Install the [PlatformIO CLI](https://platformio.org/install).
+2. (Optional) Install the Wokwi CLI with `curl -L https://wokwi.com/ci/install.sh | sh` to run the emulator.
+3. Clone this repository and run `make build` to compile the firmware.
 
 ## Directory Layout
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ This project is a template for building a Flipper Zero–compatible firmware for
 
 ## Development Setup
 
-1. Install the [PlatformIO CLI](https://platformio.org/install).
-2. (Optional) Install the Wokwi CLI with `curl -L https://wokwi.com/ci/install.sh | sh` to run the emulator.
-3. Clone this repository and run `make build` to compile the firmware.
+1. Clone this repository.
+2. Run `make env` to install the required toolchain and Python packages from
+   `requirements.txt`.
+3. (Optional) Install the Wokwi CLI with `curl -L https://wokwi.com/ci/install.sh | sh` to run the emulator.
+4. Run `make build` to compile the firmware.
 
 ## Directory Layout
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+platformio
+cpplint

--- a/scripts/install_cpplint.sh
+++ b/scripts/install_cpplint.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-uv tool install --force cpplint

--- a/scripts/install_platformio.sh
+++ b/scripts/install_platformio.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-uv tool install --force platformio

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -15,5 +15,4 @@ case "$(uname)" in
 esac
 
 "$script_dir/install_uv.sh"
-"$script_dir/install_platformio.sh"
-"$script_dir/install_cpplint.sh"
+uv pip install --system -r "$script_dir/../requirements.txt"


### PR DESCRIPTION
## Summary
- remove cpplint/platformio install helper scripts
- install Python dependencies directly in CI
- document requirements file in README

## Testing
- `make precommit` *(fails: HTTPClientError)*


------
https://chatgpt.com/codex/tasks/task_e_687ead9d8a0c832dbdb5cd9aaceb4c0c