### PR TITLE
Implement shared pin flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ TEST_SRCS = \
 	tests/test_sensor.cpp tests/test_switch.cpp \
 		tests/Arduino.cpp \
 	tests/test_button.cpp tests/test_display.cpp tests/test_digitalpin.cpp \
-	tests/test_analogpin.cpp tests/test_pwmpin.cpp tests/test_displaytile.cpp \
+        tests/test_analogpin.cpp tests/test_pwmpin.cpp tests/test_displaytile.cpp \
+        tests/test_pin_shared.cpp \
 	tests/test_memory.cpp \
 	src/Sensor.cpp src/Switch.cpp src/Button.cpp src/Display.cpp src/DisplayTile.cpp \
 	src/Pin.cpp src/DigitalPin.cpp src/AnalogPin.cpp src/PWMPin.cpp

--- a/docs/HARDWARE_ABSTRACTION_LAYER.md
+++ b/docs/HARDWARE_ABSTRACTION_LAYER.md
@@ -7,7 +7,9 @@ source files. These classes simply inherit from `Peripheral`. Specific hardware 
 should derive from one of these classes and perform any required setup in the constructor.
 
 I/O pins are represented by the templated `Pin` class with concrete implementations for
-analog (`AnalogPin`), digital (`DigitalPin`) and PWM (`PWMPin`) operation.
+analog (`AnalogPin`), digital (`DigitalPin`) and PWM (`PWMPin`) operation. Each
+pin instance tracks a boolean `isShared` flag indicating whether it may be
+purposely reused by multiple features.
 
 `Button` now also exposes `press()` and `release()` helpers that measure how long
 the button was held. The acceptable duration for a single click can be modified

--- a/include/AnalogPin.hpp
+++ b/include/AnalogPin.hpp
@@ -14,7 +14,7 @@
 class AnalogPin : public Pin<int>
 {
     public:
-    explicit AnalogPin(int number, int mode, int value = 0);
+    explicit AnalogPin(int number, int mode, int value = 0, bool isShared = false);
     ~AnalogPin() override;
 
     int read() const override;

--- a/include/DigitalPin.hpp
+++ b/include/DigitalPin.hpp
@@ -12,7 +12,7 @@
 class DigitalPin : public Pin<bool>
 {
     public:
-    explicit DigitalPin(int number, int mode, bool value = false);
+    explicit DigitalPin(int number, int mode, bool value = false, bool isShared = false);
     ~DigitalPin() override;
 
     bool read() const override;

--- a/include/PWMPin.hpp
+++ b/include/PWMPin.hpp
@@ -12,7 +12,7 @@
 class PWMPin : public Pin<int>
 {
     public:
-    explicit PWMPin(int number, int mode, int value = 0);
+    explicit PWMPin(int number, int mode, int value = 0, bool isShared = false);
     ~PWMPin() override;
     int read() const override;
     void write(int value) override;

--- a/include/Pin.hpp
+++ b/include/Pin.hpp
@@ -13,10 +13,12 @@
 template <typename T> class Pin : public Peripheral
 {
     public:
-    Pin(int number, int mode, T value = T{});
+    Pin(int number, int mode, T value = T{}, bool isShared = false);
     ~Pin() override;
     int getMode() const;
     int getPinNumber() const;
+    bool getIsShared() const;
+    void setShared(bool shared);
     virtual T read() const = 0;
     virtual void write(T value) = 0;
 
@@ -24,6 +26,7 @@ template <typename T> class Pin : public Peripheral
     int number;
     int mode;
     T value;
+    bool isShared;
 };
 
 #endif // PIN_HPP

--- a/src/AnalogPin.cpp
+++ b/src/AnalogPin.cpp
@@ -7,7 +7,7 @@
 #include "AnalogPin.hpp"
 #include <Arduino.h>
 
-AnalogPin::AnalogPin(int number, int mode, int value) : Pin<int>(number, mode, value)
+AnalogPin::AnalogPin(int number, int mode, int value, bool isShared) : Pin<int>(number, mode, value, isShared)
 {
 }
 

--- a/src/DigitalPin.cpp
+++ b/src/DigitalPin.cpp
@@ -7,7 +7,7 @@
 #include "DigitalPin.hpp"
 #include <Arduino.h>
 
-DigitalPin::DigitalPin(int number, int mode, bool value) : Pin<bool>(number, mode, value)
+DigitalPin::DigitalPin(int number, int mode, bool value, bool isShared) : Pin<bool>(number, mode, value, isShared)
 {
 }
 

--- a/src/PWMPin.cpp
+++ b/src/PWMPin.cpp
@@ -7,7 +7,7 @@
 #include "PWMPin.hpp"
 #include <Arduino.h>
 
-PWMPin::PWMPin(int number, int mode, int value) : Pin<int>(number, mode, value)
+PWMPin::PWMPin(int number, int mode, int value, bool isShared) : Pin<int>(number, mode, value, isShared)
 {
 }
 

--- a/src/Pin.cpp
+++ b/src/Pin.cpp
@@ -9,7 +9,7 @@
 
 template <typename T>
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-Pin<T>::Pin(int number, int mode, T value) : number(number), mode(mode), value(value)
+Pin<T>::Pin(int number, int mode, T value, bool isShared) : number(number), mode(mode), value(value), isShared(isShared)
 {
     pinMode(number, mode);
 }
@@ -26,6 +26,16 @@ template <typename T> int Pin<T>::getMode() const
 template <typename T> int Pin<T>::getPinNumber() const
 {
     return number;
+}
+
+template <typename T> bool Pin<T>::getIsShared() const
+{
+    return isShared;
+}
+
+template <typename T> void Pin<T>::setShared(bool shared)
+{
+    isShared = shared;
 }
 
 // Explicit template instantiations for bool and int

--- a/tests/test_pin_shared.cpp
+++ b/tests/test_pin_shared.cpp
@@ -1,0 +1,10 @@
+#include "DigitalPin.hpp"
+#include "catch_amalgamated.hpp"
+
+TEST_CASE("Pin shared flag", "[pin]")
+{
+    DigitalPin pin(13, OUTPUT, false); // default not shared
+    REQUIRE_FALSE(pin.getIsShared());
+    pin.setShared(true);
+    REQUIRE(pin.getIsShared());
+}


### PR DESCRIPTION
## Summary
- extend Pin class with isShared support
- propagate isShared flag to analog/digital/PWM pins
- document isShared in HAL docs
- test shared flag behavior

## Testing
- `make test`
- `make coverage`
- ❌ `make precommit` (fails during `platformio` build due to network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_687fdd288ad0832da53daf9c48edf3ec