### PR TITLE
Add shared flag to Pin classes

### DIFF
--- a/docs/HARDWARE_ABSTRACTION_LAYER.md
+++ b/docs/HARDWARE_ABSTRACTION_LAYER.md
@@ -7,7 +7,10 @@ source files. These classes simply inherit from `Peripheral`. Specific hardware 
 should derive from one of these classes and perform any required setup in the constructor.
 
 I/O pins are represented by the templated `Pin` class with concrete implementations for
-analog (`AnalogPin`), digital (`DigitalPin`) and PWM (`PWMPin`) operation.
+analog (`AnalogPin`), digital (`DigitalPin`) and PWM (`PWMPin`) operation. Each
+`Pin` instance can be flagged as *shared* using the optional `isShared`
+constructor argument to allow reuse of protocols like I2C and SPI when future
+validation prevents duplicate pin assignments.
 
 `Button` now also exposes `press()` and `release()` helpers that measure how long
 the button was held. The acceptable duration for a single click can be modified

--- a/include/AnalogPin.hpp
+++ b/include/AnalogPin.hpp
@@ -14,7 +14,7 @@
 class AnalogPin : public Pin<int>
 {
     public:
-    explicit AnalogPin(int number, int mode, int value = 0);
+    explicit AnalogPin(int number, int mode, int value = 0, bool shared = false);
     ~AnalogPin() override;
 
     int read() const override;

--- a/include/DigitalPin.hpp
+++ b/include/DigitalPin.hpp
@@ -12,7 +12,7 @@
 class DigitalPin : public Pin<bool>
 {
     public:
-    explicit DigitalPin(int number, int mode, bool value = false);
+    explicit DigitalPin(int number, int mode, bool value = false, bool shared = false);
     ~DigitalPin() override;
 
     bool read() const override;

--- a/include/PWMPin.hpp
+++ b/include/PWMPin.hpp
@@ -12,7 +12,7 @@
 class PWMPin : public Pin<int>
 {
     public:
-    explicit PWMPin(int number, int mode, int value = 0);
+    explicit PWMPin(int number, int mode, int value = 0, bool shared = false);
     ~PWMPin() override;
     int read() const override;
     void write(int value) override;

--- a/include/Pin.hpp
+++ b/include/Pin.hpp
@@ -13,10 +13,11 @@
 template <typename T> class Pin : public Peripheral
 {
     public:
-    Pin(int number, int mode, T value = T{});
+    Pin(int number, int mode, T value = T{}, bool shared = false);
     ~Pin() override;
     int getMode() const;
     int getPinNumber() const;
+    bool isShared() const;
     virtual T read() const = 0;
     virtual void write(T value) = 0;
 
@@ -24,6 +25,7 @@ template <typename T> class Pin : public Peripheral
     int number;
     int mode;
     T value;
+    bool shared{false};
 };
 
 #endif // PIN_HPP

--- a/src/AnalogPin.cpp
+++ b/src/AnalogPin.cpp
@@ -7,7 +7,7 @@
 #include "AnalogPin.hpp"
 #include <Arduino.h>
 
-AnalogPin::AnalogPin(int number, int mode, int value) : Pin<int>(number, mode, value)
+AnalogPin::AnalogPin(int number, int mode, int value, bool shared) : Pin<int>(number, mode, value, shared)
 {
 }
 

--- a/src/DigitalPin.cpp
+++ b/src/DigitalPin.cpp
@@ -7,7 +7,7 @@
 #include "DigitalPin.hpp"
 #include <Arduino.h>
 
-DigitalPin::DigitalPin(int number, int mode, bool value) : Pin<bool>(number, mode, value)
+DigitalPin::DigitalPin(int number, int mode, bool value, bool shared) : Pin<bool>(number, mode, value, shared)
 {
 }
 

--- a/src/PWMPin.cpp
+++ b/src/PWMPin.cpp
@@ -7,7 +7,7 @@
 #include "PWMPin.hpp"
 #include <Arduino.h>
 
-PWMPin::PWMPin(int number, int mode, int value) : Pin<int>(number, mode, value)
+PWMPin::PWMPin(int number, int mode, int value, bool shared) : Pin<int>(number, mode, value, shared)
 {
 }
 

--- a/src/Pin.cpp
+++ b/src/Pin.cpp
@@ -9,7 +9,7 @@
 
 template <typename T>
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-Pin<T>::Pin(int number, int mode, T value) : number(number), mode(mode), value(value)
+Pin<T>::Pin(int number, int mode, T value, bool shared) : number(number), mode(mode), value(value), shared(shared)
 {
     pinMode(number, mode);
 }
@@ -26,6 +26,11 @@ template <typename T> int Pin<T>::getMode() const
 template <typename T> int Pin<T>::getPinNumber() const
 {
     return number;
+}
+
+template <typename T> bool Pin<T>::isShared() const
+{
+    return shared;
 }
 
 // Explicit template instantiations for bool and int

--- a/tests/test_analogpin.cpp
+++ b/tests/test_analogpin.cpp
@@ -42,3 +42,11 @@ TEST_CASE("AnalogPin constructor sets hardware pin mode", "[analogpin]")
     AnalogPin inputPin(30, INPUT);
     REQUIRE(pinModes[30] == INPUT);
 }
+
+TEST_CASE("AnalogPin shared flag", "[analogpin]")
+{
+    AnalogPin sharedPin(22, OUTPUT, 0, true);
+    REQUIRE(sharedPin.isShared());
+    AnalogPin exclusivePin(23, OUTPUT);
+    REQUIRE_FALSE(exclusivePin.isShared());
+}

--- a/tests/test_digitalpin.cpp
+++ b/tests/test_digitalpin.cpp
@@ -46,3 +46,11 @@ TEST_CASE("DigitalPin constructor sets hardware pin mode", "[digitalpin]")
     DigitalPin inputPin(10, INPUT);
     REQUIRE(pinModes[10] == INPUT);
 }
+
+TEST_CASE("DigitalPin shared flag", "[digitalpin]")
+{
+    DigitalPin sharedPin(20, OUTPUT, false, true);
+    REQUIRE(sharedPin.isShared());
+    DigitalPin exclusivePin(21, OUTPUT);
+    REQUIRE_FALSE(exclusivePin.isShared());
+}

--- a/tests/test_pwmpin.cpp
+++ b/tests/test_pwmpin.cpp
@@ -24,3 +24,11 @@ TEST_CASE("PWMPin constructor sets hardware pin mode", "[pwmpin]")
     PWMPin inputPin(12, INPUT);
     REQUIRE(pinModes[12] == INPUT);
 }
+
+TEST_CASE("PWMPin shared flag", "[pwmpin]")
+{
+    PWMPin sharedPin(24, OUTPUT, 0, true);
+    REQUIRE(sharedPin.isShared());
+    PWMPin exclusivePin(25, OUTPUT);
+    REQUIRE_FALSE(exclusivePin.isShared());
+}


### PR DESCRIPTION
## Summary
- add `shared` flag to `Pin` class
- propagate new flag through pin-derived classes
- document the flag in HAL documentation
- add unit tests for the `shared` property

## Testing
- `make test`
- `make coverage`
- `make cpplint`
- `make lint`
- `make tidy`


------
https://chatgpt.com/codex/tasks/task_e_687fecf91c58832db3f88b5b5c8158c7