### PR TITLE
Fix TOML pipeline and add compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
               - 'Doxyfile'
               - 'diagram.json'
               - 'wokwi.toml'
+              - '**/*.toml'
             tests:
               - 'tests/**'
             markdown:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 platformio
 cpplint
+tomli

--- a/scripts/wokwi_sanity.py
+++ b/scripts/wokwi_sanity.py
@@ -4,7 +4,10 @@
 import json
 import os
 import sys
-import tomllib
+try:  # tomllib is available in Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - fallback for older Pythons
+    import tomli as tomllib  # type: ignore
 
 WOKWI_TOML = "wokwi.toml"
 


### PR DESCRIPTION
## Summary
- fallback to `tomli` when Python version lacks `tomllib`
- install `tomli` in the dev environment
- trigger CI when any `.toml` file changes

## Testing
- `make precommit` *(fails: HTTPClientError during build)*

------
https://chatgpt.com/codex/tasks/task_e_68864be133cc832d88b94a9c095e470e