### PR TITLE
ISSUE#144: automate post-merge issue closing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,3 +133,18 @@ jobs:
             make ${{ matrix.task }}
           fi
 
+  close-issues:
+    needs: [build]
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+      - name: Close referenced issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 scripts/close_issues.py "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.merge_commit_sha }}"
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,11 @@ All commit messages **must** start with one of the following prefixes:
 * `FIX:`
 * `FEATURE:`
 * `ISSUE#<number>:`
+* `FIXES#<number>:`
+* `CLOSES#<number>:`
+
+These `FIXES#` and `CLOSES#` prefixes may be written in any mix of uppercase or
+lowercase letters.
 
 Example:
 
@@ -57,5 +62,18 @@ FIX: correct sensor initialization sequence
 
 This ensures a consistent project history and helps automation tools categorize
 changes correctly.
+
+## Post-Merge Issue Closure
+
+After a pull request is merged, the CI pipeline automatically closes issues that
+meet **all** of the following conditions:
+
+1. The issue has the `Codex` label.
+2. Any commit message in the merged range contains `fixes#<issue>` or
+   `closes#<issue>` (case-insensitive).
+3. The issue is still open.
+
+This automation only runs after merges and never closes issues based solely on
+open pull requests.
 
 Maintainers: Codex

--- a/scripts/check_commit_prefix.py
+++ b/scripts/check_commit_prefix.py
@@ -4,7 +4,9 @@ import re
 import subprocess
 import sys
 
-PREFIX_RE = re.compile(r"^(HOTFIX:|FIX:|FEATURE:|ISSUE#[0-9]+:)")
+PREFIX_RE = re.compile(
+    r"^(HOTFIX:|FIX:|FEATURE:|ISSUE#[0-9]+:|(?i:(?:fixes|closes)#[0-9]+:))"
+)
 GOOD = "\u2714"  # check mark
 BAD = "X"  # invalid mark
 RETURN = "\u21a9"  # return arrow for hints

--- a/scripts/close_issues.py
+++ b/scripts/close_issues.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Close GitHub issues referenced by commit messages."""
+import json
+import os
+import re
+import subprocess
+import sys
+from urllib.request import Request, urlopen
+
+CLOSE_RE = re.compile(r"(fixes|closes)#(\d+)", re.IGNORECASE)
+
+
+def get_commit_messages(base: str, head: str) -> list[str]:
+    try:
+        out = subprocess.check_output([
+            "git",
+            "log",
+            f"{base}..{head}",
+            "--format=%s",
+            "--no-merges",
+        ], text=True)
+    except subprocess.CalledProcessError as exc:
+        print(f"error: unable to read git log: {exc}", file=sys.stderr)
+        return []
+    return [line.strip() for line in out.splitlines()]
+
+
+def fetch_issue(repo: str, token: str, number: str) -> dict | None:
+    url = f"https://api.github.com/repos/{repo}/issues/{number}"
+    req = Request(url, headers={"Authorization": f"token {token}", "Accept": "application/vnd.github+json"})
+    try:
+        with urlopen(req) as resp:
+            return json.load(resp)
+    except Exception as exc:
+        print(f"warning: unable to read issue #{number}: {exc}", file=sys.stderr)
+        return None
+
+
+def close_issue(repo: str, token: str, number: str) -> None:
+    url = f"https://api.github.com/repos/{repo}/issues/{number}"
+    data = json.dumps({"state": "closed"}).encode()
+    req = Request(url, data=data, method="PATCH", headers={
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    })
+    try:
+        with urlopen(req):
+            pass
+    except Exception as exc:
+        print(f"warning: unable to close issue #{number}: {exc}", file=sys.stderr)
+
+
+def main(base: str, head: str) -> int:
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    token = os.environ.get("GITHUB_TOKEN")
+    if not repo or not token:
+        print("error: GITHUB_REPOSITORY and GITHUB_TOKEN must be set", file=sys.stderr)
+        return 1
+
+    issues: set[str] = set()
+    for msg in get_commit_messages(base, head):
+        for m in CLOSE_RE.finditer(msg):
+            issues.add(m.group(2))
+
+    for number in issues:
+        data = fetch_issue(repo, token, number)
+        if not data or data.get("state") == "closed":
+            continue
+        labels = {lbl["name"].lower() for lbl in data.get("labels", [])}
+        if "codex" not in labels:
+            continue
+        close_issue(repo, token, number)
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: close_issues.py <base_sha> <head_sha>", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(main(sys.argv[1], sys.argv[2]))


### PR DESCRIPTION
## Summary
- close labeled issues automatically in CI
- support `FIXES#` and `CLOSES#` commit prefixes
- document auto-closing behaviour

## Testing
- `make env`
- `make precommit` *(fails: HTTPClientError during platformio run)*

------
https://chatgpt.com/codex/tasks/task_e_6887f3e80588832da24b10bb2ad2299b