### PR TITLE
FIX: allow GitHub issue closing keywords

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -4,8 +4,10 @@ set -euo pipefail
 msg_file="$1"
 first_line="$(head -n1 "$msg_file" | tr -d '\r')"
 
-if [[ ! "$first_line" =~ ^(HOTFIX:|FIX:|FEATURE:|ISSUE#[0-9]+:) ]]; then
-    echo "Error: commit message must start with one of: HOTFIX:, FIX:, FEATURE:, ISSUE#<number>:" >&2
+pattern='^((hotfix|fix|feature)[[:space:]]*(:|-)[[:space:]]*|issue#[0-9]+[[:space:]]*(:|-)[[:space:]]*|(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)[[:space:]]+#?[0-9]+)'
+
+if ! echo "$first_line" | grep -Eiq "$pattern"; then
+    echo "Error: commit message must start with HOTFIX, FIX, FEATURE, ISSUE#<number>, or a GitHub closing keyword like 'Fixes #123'." >&2
     exit 1
 fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,17 +42,18 @@ and verifies that unit test coverage remains at 100%. Fix any failures before
 opening a pull request or pushing commits.
 
 ## Commit Message Format
-All commit messages **must** start with one of the following prefixes:
+All commit messages **must** start with one of the following patterns:
 
-* `HOTFIX:`
-* `FIX:`
-* `FEATURE:`
-* `ISSUE#<number>:`
+* `HOTFIX`, `FIX`, `FEATURE`, or `ISSUE#<number>` followed by `:` or `-`
+* A GitHub issue-closing keyword such as `fixes`, `closes`, or `resolves` followed by `#<number>`
+
+Keywords may be written in **uppercase**, **lowercase**, or **Title Case**. A space may optionally appear around the dash.
 
 Example:
 
 ```text
-FIX: correct sensor initialization sequence
+fix - correct sensor initialization sequence
+Fixes #42 - adjust button debounce logic
 ```
 
 This ensures a consistent project history and helps automation tools categorize

--- a/scripts/check_commit_prefix.py
+++ b/scripts/check_commit_prefix.py
@@ -4,7 +4,10 @@ import re
 import subprocess
 import sys
 
-PREFIX_RE = re.compile(r"^(HOTFIX:|FIX:|FEATURE:|ISSUE#[0-9]+:)")
+PREFIX_RE = re.compile(
+    r"^(?:\s*(?:hotfix|fix|feature)\s*(?:[:]|-\s*)\s*|issue#[0-9]+\s*(?:[:]|-\s*)\s*|(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#\d+(?:\s*(?:[:]|-\s*)\s*)?)",
+    re.IGNORECASE,
+)
 GOOD = "\u2714"  # check mark
 BAD = "X"  # invalid mark
 RETURN = "\u21a9"  # return arrow for hints
@@ -31,7 +34,8 @@ def main(base: str) -> int:
         else:
             print(f"{BAD} {line}")
             print(
-                f"   {RETURN} commit message must start with HOTFIX:, FIX:, FEATURE:, or ISSUE#<number>:"
+                f"   {RETURN} commit message must start with HOTFIX, FIX, FEATURE, ISSUE#<number>, "
+                "or a GitHub closing keyword like 'Fixes #123'."
             )
             bad = True
     return 1 if bad else 0


### PR DESCRIPTION
## Summary
- update commit message guidelines for issue closing keywords
- support closing keywords in commit prefix check script
- loosen commit-msg hook checks

## Testing
- `make precommit` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_6887f8198404832d951778cedce1a91f