### PR TITLE
FEATURE: enhance commit message check outputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,14 +25,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Validate commit messages
-        run: |
-          output=$(scripts/check_commit_prefix.py "${{ github.event.pull_request.base.sha }}")
-          echo "$output"
-          {
-            echo '```'
-            echo "$output"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+        run: scripts/check_commit_prefix.py "${{ github.event.pull_request.base.sha }}"
 
   # Build the firmware
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Validate commit messages
-        run: scripts/check_commit_prefix.py "${{ github.event.pull_request.base.sha }}"
+        run: |
+          output=$(scripts/check_commit_prefix.py "${{ github.event.pull_request.base.sha }}")
+          echo "$output"
+          {
+            echo '```'
+            echo "$output"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # Build the firmware
   build:

--- a/scripts/check_commit_prefix.py
+++ b/scripts/check_commit_prefix.py
@@ -7,7 +7,7 @@ import sys
 PREFIX_RE = re.compile(r"^(HOTFIX:|FIX:|FEATURE:|ISSUE#[0-9]+:)")
 GOOD = "\u2714"  # check mark
 BAD = "X"  # invalid mark
-RETURN = "\u21a9"  # return arrow for hints
+RETURN = "\u21a6"  # ↦ arrow for hints
 
 
 def main(base: str) -> int:
@@ -27,9 +27,9 @@ def main(base: str) -> int:
     for line in log.splitlines():
         line = line.strip()
         if PREFIX_RE.match(line):
-            print(f"{GOOD} {line}")
+            print(f"{line} {GOOD}")
         else:
-            print(f"{BAD} {line}")
+            print(f"{line} {BAD}")
             print(
                 f"   {RETURN} commit message must start with HOTFIX:, FIX:, FEATURE:, or ISSUE#<number>:"
             )


### PR DESCRIPTION
## Summary
- tweak `check_commit_prefix.py` output
- send commit check results to the step summary

## Testing
- `make env`
- `make check-format`
- `make precommit` *(fails: Platform Manager installing espressif32)*

------
https://chatgpt.com/codex/tasks/task_e_68895047d680832d970e9d03ecdb85e0