### PR TITLE
Add optional border flag for DisplayTile creation

### DIFF
--- a/include/Display.hpp
+++ b/include/Display.hpp
@@ -35,7 +35,7 @@ class Display : public Peripheral
      *
      * @param dims Physical dimensions of the display in characters.
      */
-    explicit Display(Dimensions dims);
+    explicit Display(Dimensions dims, bool border = false);
 
     /** Destructor. */
     ~Display() override;
@@ -71,11 +71,12 @@ class Display : public Peripheral
      * @param dims   Dimensions of the tile.
      * @return A new DisplayTile managing the region.
      */
-    DisplayTile createTile(Point origin, Dimensions dims);
+    DisplayTile createTile(Point origin, Dimensions dims, bool border = false);
 
     protected:
     int width;
     int height;
+    bool border;
     std::vector<Rect> tiles;
     std::vector<std::vector<unsigned char>> buffer;
     std::vector<std::vector<std::vector<unsigned char>>> stack;

--- a/include/DisplayTile.hpp
+++ b/include/DisplayTile.hpp
@@ -29,7 +29,7 @@ class DisplayTile
      * @param dims     Dimensions of the tile.
      * @param siblings Container tracking sibling rectangles for collision detection.
      */
-    DisplayTile(Display& root, Point origin, Dimensions dims, std::vector<Rect>& siblings);
+    DisplayTile(Display& root, Point origin, Dimensions dims, std::vector<Rect>& siblings, bool border = false);
 
     /** @return Width of the tile in characters. */
     int getWidth() const;
@@ -44,7 +44,7 @@ class DisplayTile
      * @param dims   Dimensions of the new tile.
      * @return A new DisplayTile instance.
      */
-    DisplayTile createTile(Point origin, Dimensions dims);
+    DisplayTile createTile(Point origin, Dimensions dims, bool border = false);
 
     /**
      * @brief Draw bytes relative to the tile origin.
@@ -80,6 +80,7 @@ class DisplayTile
     std::vector<Rect>& siblings;
     std::vector<Rect> children;
     bool focused{false};
+    bool border{false};
 };
 
 #endif // DISPLAYTILE_HPP

--- a/src/Display.cpp
+++ b/src/Display.cpp
@@ -18,7 +18,7 @@ static Adafruit_SSD1306 oled(128, 64, &Wire);
 #endif
 
 /** Construct a display with the given dimensions. */
-Display::Display(Dimensions dims) : width(dims.width), height(dims.height)
+Display::Display(Dimensions dims, bool border) : width(dims.width), height(dims.height), border(border)
 {
 #ifdef ARDUINO
     oled.begin(SSD1306_SWITCHCAPVCC, 0x3C);
@@ -68,7 +68,7 @@ void Display::drawBytes(Point pos, const unsigned char* data, std::size_t length
 }
 
 /** Create a tile that represents a sub-region of the display. */
-DisplayTile Display::createTile(Point origin, Dimensions dims)
+DisplayTile Display::createTile(Point origin, Dimensions dims, bool border)
 {
     Rect r{origin.x, origin.y, dims.width, dims.height};
     auto collide = [&r](const Rect& t) {
@@ -78,7 +78,7 @@ DisplayTile Display::createTile(Point origin, Dimensions dims)
     {
         throw std::runtime_error("Tile collision");
     }
-    return DisplayTile(*this, origin, dims, tiles);
+    return DisplayTile(*this, origin, dims, tiles, border);
 }
 
 /** Save the current buffer to the stack for later restoration. */

--- a/src/DisplayTile.cpp
+++ b/src/DisplayTile.cpp
@@ -16,8 +16,8 @@ static bool collides(const Rect& a, const Rect& b)
 }
 
 /** Create a tile managed by a parent display. */
-DisplayTile::DisplayTile(Display& root, Point origin, Dimensions dims, std::vector<Rect>& siblings)
-    : root(root), origin(origin), dims(dims), siblings(siblings)
+DisplayTile::DisplayTile(Display& root, Point origin, Dimensions dims, std::vector<Rect>& siblings, bool border)
+    : root(root), origin(origin), dims(dims), siblings(siblings), border(border)
 {
     Rect r{origin.x, origin.y, dims.width, dims.height};
     auto collide = [&r](const Rect& s) { return collides(r, s); };
@@ -40,7 +40,7 @@ int DisplayTile::getHeight() const
 }
 
 /** Create a child tile relative to this tile. */
-DisplayTile DisplayTile::createTile(Point origin, Dimensions dims)
+DisplayTile DisplayTile::createTile(Point origin, Dimensions dims, bool border)
 {
     if (origin.x < 0 || origin.y < 0 || origin.x + dims.width > this->dims.width ||
         origin.y + dims.height > this->dims.height)
@@ -48,7 +48,7 @@ DisplayTile DisplayTile::createTile(Point origin, Dimensions dims)
         throw std::runtime_error("Tile collision");
     }
     Point abs{this->origin.x + origin.x, this->origin.y + origin.y};
-    return DisplayTile(root, abs, dims, children);
+    return DisplayTile(root, abs, dims, children, border);
 }
 
 /** Draw bytes relative to the tile origin. */
@@ -88,6 +88,10 @@ void DisplayTile::focus()
         return;
     }
     focused = true;
+    if (!border)
+    {
+        return;
+    }
     unsigned char dot = '.';
     for (int x = 0; x < dims.width; ++x)
     {
@@ -115,6 +119,10 @@ void DisplayTile::unfocus()
         return;
     }
     focused = false;
+    if (!border)
+    {
+        return;
+    }
     unsigned char space = ' ';
     for (int x = 0; x < dims.width; ++x)
     {

--- a/tests/test_displaytile.cpp
+++ b/tests/test_displaytile.cpp
@@ -122,7 +122,7 @@ static int expected_focus_calls(int w, int h)
 TEST_CASE("focus and unfocus draw border", "[displaytile]")
 {
     LoggingDisplay d;
-    DisplayTile t = d.createTile({0, 0}, {3, 3});
+    DisplayTile t = d.createTile({0, 0}, {3, 3}, true);
     int before = d.calls;
     t.focus();
     int expected = expected_focus_calls(3, 3);
@@ -135,7 +135,7 @@ TEST_CASE("focus and unfocus draw border", "[displaytile]")
 TEST_CASE("isOnFocus controls border drawing", "[displaytile]")
 {
     LoggingDisplay d;
-    DisplayTile t = d.createTile({0, 0}, {4, 2});
+    DisplayTile t = d.createTile({0, 0}, {4, 2}, true);
     REQUIRE_FALSE(t.isOnFocus());
     int before = d.calls;
     t.focus();


### PR DESCRIPTION
## Summary
- allow `Display` and `DisplayTile` to specify a border flag
- propagate the flag through `createTile` functions
- guard focus/unfocus drawing with the border flag
- update tests for the new parameter

## Testing
- `make test`
- `make precommit` *(fails: PlatformIO cannot install espressif32)*

------
https://chatgpt.com/codex/tasks/task_e_6889693ba3bc832d9a0cb90034f6d741