### PR TITLE
Add Valgrind support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        task: [check-format, lint, cpplint, tidy, docs-check, markdown-lint, makefile-lint, env]
+        task: [check-format, lint, cpplint, tidy, docs-check, markdown-lint, makefile-lint, env, valgrind]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -121,7 +121,7 @@ jobs:
         run: bash scripts/install_uv.sh
       - name: Install tools
         run: |  # Install linting tools for sanity checks
-          bash scripts/install_apt_packages.sh cppcheck clang-format clang-tidy doxygen
+          bash scripts/install_apt_packages.sh cppcheck clang-format clang-tidy doxygen valgrind
           uv pip install --system -r requirements.txt
       - name: Run ${{ matrix.task }}
         run: |  # Execute the requested sanity task
@@ -129,6 +129,8 @@ jobs:
             make markdown-lint
           elif [ "${{ matrix.task }}" = "env" ]; then
             make env && make build
+          elif [ "${{ matrix.task }}" = "valgrind" ]; then
+            make valgrind
           else
             make ${{ matrix.task }}
           fi

--- a/tools/valgrind_main.cpp
+++ b/tools/valgrind_main.cpp
@@ -1,0 +1,54 @@
+/**
+ * @file valgrind_main.cpp
+ * @brief Minimal host application used for Valgrind checks.
+ */
+
+#include "AnalogPin.hpp"
+#include "DigitalPin.hpp"
+#include "Display.hpp"
+#include "DisplayTile.hpp"
+#include <vector>
+
+class DummyDisplay : public Display
+{
+public:
+    DummyDisplay() : Display({4, 4}) {}
+    void drawBytes(Point pos, const unsigned char* data, std::size_t length) override
+    {
+        Display::drawBytes(pos, data, length);
+    }
+};
+#include "PWMPin.hpp"
+#include "Button.hpp"
+#include "Sensor.hpp"
+#include "Switch.hpp"
+#include "Arduino.h"
+
+int main()
+{
+    AnalogPin a(0, INPUT);
+    a.read();
+    a.write(1);
+
+    DigitalPin d(1, OUTPUT);
+    d.write(1);
+    d.read();
+
+    PWMPin p(2, OUTPUT);
+    p.write(true);
+
+    Button b;
+    b.press();
+    b.release();
+
+    Sensor s;
+    Switch sw;
+
+    DummyDisplay display;
+    auto tile = display.createTile({0, 0}, {2, 2});
+    tile.focus();
+    tile.unfocus();
+    display.clear();
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a valgrind main program for runtime checks
- support `make valgrind`
- run valgrind in CI

## Testing
- `make valgrind`
- `make precommit` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_6889ae4e2a88832d93fde13c826520a4