### PR TITLE
Add ST7735 display support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,12 @@ TEST_SRCS = \
         tests/test_button.cpp tests/test_display.cpp tests/test_digitalpin.cpp \
         tests/test_analogpin.cpp tests/test_pwmpin.cpp tests/test_tile.cpp \
         tests/test_memory.cpp \
-        src/Sensor.cpp src/Switch.cpp src/Button.cpp src/Display.cpp src/Tile.cpp \
+        src/Sensor.cpp src/Switch.cpp src/Button.cpp src/Display.cpp src/TFTST7735Display.cpp src/Tile.cpp \
         src/Pin.cpp src/DigitalPin.cpp src/AnalogPin.cpp src/PWMPin.cpp
 
 HOST_FLAGS = -Itests -Iinclude -std=c++17 -Wall -Wextra -Werror
 VALGRIND_SRCS = tools/valgrind_main.cpp tests/Arduino.cpp \
-        src/Sensor.cpp src/Switch.cpp src/Button.cpp src/Display.cpp \
+        src/Sensor.cpp src/Switch.cpp src/Button.cpp src/Display.cpp src/TFTST7735Display.cpp \
         src/Tile.cpp src/Pin.cpp src/DigitalPin.cpp \
         src/AnalogPin.cpp src/PWMPin.cpp
 

--- a/include/TFTST7735Display.hpp
+++ b/include/TFTST7735Display.hpp
@@ -1,0 +1,39 @@
+#ifndef TFTST7735DISPLAY_HPP
+#define TFTST7735DISPLAY_HPP
+
+#include <cstdint>
+#include "Display.hpp"
+
+#ifdef ARDUINO
+#include <Adafruit_GFX.h>
+#include <Adafruit_ST7735.h>
+#endif
+
+/**
+ * @brief Display driver for 1.8" TFT ST7735 screens.
+ */
+class TFTST7735Display : public Display
+{
+    public:
+    /**
+     * @brief Construct a ST7735 display.
+     *
+     * @param dims Physical dimensions of the display in characters.
+     * @param cs   Chip select pin.
+     * @param dc   Data/command pin.
+     * @param rst  Reset pin.
+     */
+    TFTST7735Display(Dimensions dims, int8_t cs, int8_t dc, int8_t rst);
+
+    /**
+     * @brief Draw bytes on the TFT display.
+     */
+    void drawBytes(Point pos, const unsigned char* data, std::size_t length) override;
+
+    private:
+#ifdef ARDUINO
+    Adafruit_ST7735 tft;
+#endif
+};
+
+#endif // TFTST7735DISPLAY_HPP

--- a/platformio.ini
+++ b/platformio.ini
@@ -6,6 +6,7 @@ monitor_speed = 115200
 lib_deps =
     adafruit/Adafruit SSD1306
     adafruit/Adafruit GFX Library
+    adafruit/Adafruit ST7735 and ST7789 Library
 build_flags =
     -Wall -Wextra -Werror
 

--- a/src/Display.cpp
+++ b/src/Display.cpp
@@ -10,20 +10,9 @@
 #include <vector>
 #include "Tile.hpp"
 
-#ifdef ARDUINO
-#include <Adafruit_GFX.h>
-#include <Adafruit_SSD1306.h>
-
-static Adafruit_SSD1306 oled(128, 64, &Wire);
-#endif
-
 /** Construct a display with the given dimensions. */
 Display::Display(Dimensions dims) : width(dims.width), height(dims.height)
 {
-#ifdef ARDUINO
-    oled.begin(SSD1306_SWITCHCAPVCC, 0x3C);
-    oled.clearDisplay();
-#endif
     buffer.resize(height, std::vector<unsigned char>(width, ' '));
 }
 
@@ -44,18 +33,9 @@ int Display::getHeight() const
 /** Draw raw bytes at the specified display coordinate. */
 void Display::drawBytes(Point pos, const unsigned char* data, std::size_t length)
 {
-#ifdef ARDUINO
-    oled.setCursor(pos.x, pos.y);
-    for (std::size_t i = 0; i < length; ++i)
-    {
-        oled.write(data[i]);
-    }
-    oled.display();
-#else
     (void) pos;
     (void) data;
     (void) length;
-#endif
     for (std::size_t i = 0; i < length; ++i)
     {
         int x = pos.x + static_cast<int>(i);

--- a/src/TFTST7735Display.cpp
+++ b/src/TFTST7735Display.cpp
@@ -1,0 +1,41 @@
+/**
+ * @file TFTST7735Display.cpp
+ * @brief Implementation of the ST7735 TFT display driver.
+ */
+
+#include "TFTST7735Display.hpp"
+
+#ifdef ARDUINO
+#include <SPI.h>
+#endif
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+TFTST7735Display::TFTST7735Display(Dimensions dims, int8_t cs, int8_t dc, int8_t rst)
+    : Display(dims)
+#ifdef ARDUINO
+      ,
+      tft(cs, dc, rst)
+#endif
+{
+#ifdef ARDUINO
+    tft.initR(INITR_BLACKTAB);
+    tft.setRotation(1);
+    tft.fillScreen(ST77XX_BLACK);
+#else
+    (void) cs;
+    (void) dc;
+    (void) rst;
+#endif
+}
+
+void TFTST7735Display::drawBytes(Point pos, const unsigned char* data, std::size_t length)
+{
+#ifdef ARDUINO
+    tft.setCursor(pos.x, pos.y);
+    for (std::size_t i = 0; i < length; ++i)
+    {
+        tft.write(data[i]);
+    }
+#endif
+    Display::drawBytes(pos, data, length);
+}

--- a/src/TFTST7735Display.cpp
+++ b/src/TFTST7735Display.cpp
@@ -7,6 +7,7 @@
 
 #ifdef ARDUINO
 #include <SPI.h>
+#include <Adafruit_ST7735.h>
 #endif
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)

--- a/tests/test_display.cpp
+++ b/tests/test_display.cpp
@@ -1,5 +1,6 @@
 #include "Display.hpp"
 #include "MemoryTracker.hpp"
+#include "TFTST7735Display.hpp"
 #include "catch_amalgamated.hpp"
 
 class DummyDisplay : public Display
@@ -90,4 +91,13 @@ TEST_CASE("popState throws if no state saved", "[display]")
 {
     StateDisplay d;
     REQUIRE_THROWS_AS(d.popState(), std::runtime_error);
+}
+
+TEST_CASE("TFTST7735Display stores dimensions", "[display]")
+{
+    TFTST7735Display d({128, 160}, 0, 0, 0);
+    unsigned char msg[] = "abcd";
+    d.drawBytes({0, 0}, msg, 4);
+    REQUIRE(d.getWidth() == 128);
+    REQUIRE(d.getHeight() == 160);
 }


### PR DESCRIPTION
## Summary
- implement a TFTST7735Display driver for 1.8" ST7735 screens
- make the base Display hardware-agnostic and wire new driver into the build and tests
- expand unit tests to exercise the ST7735 display

## Testing
- `make cpplint`
- `make lint`
- `make tidy`
- `make docs-check`
- `make check-format`
- `make markdown-lint`
- `make makefile-lint`
- `make test`
- `make coverage`
- `make precommit` *(fails: HTTPClientError while installing espressif32 platform)*

------
https://chatgpt.com/codex/tasks/task_e_688e9a6bb7b8832db2c6486a10130ef8