### PR TITLE
FEATURE: abstract Display interface and SSD1306 subclass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,12 @@ TEST_SRCS = \
         tests/test_button.cpp tests/test_display.cpp tests/test_digitalpin.cpp \
         tests/test_analogpin.cpp tests/test_pwmpin.cpp tests/test_tile.cpp \
         tests/test_memory.cpp \
-        src/Sensor.cpp src/Switch.cpp src/Button.cpp src/Display.cpp src/Tile.cpp \
+        src/Sensor.cpp src/Switch.cpp src/Button.cpp src/Display.cpp src/AdafruitSSD1306Display.cpp src/Tile.cpp \
         src/Pin.cpp src/DigitalPin.cpp src/AnalogPin.cpp src/PWMPin.cpp
 
 HOST_FLAGS = -Itests -Iinclude -std=c++17 -Wall -Wextra -Werror
 VALGRIND_SRCS = tools/valgrind_main.cpp tests/Arduino.cpp \
-        src/Sensor.cpp src/Switch.cpp src/Button.cpp src/Display.cpp \
+        src/Sensor.cpp src/Switch.cpp src/Button.cpp src/Display.cpp src/AdafruitSSD1306Display.cpp \
         src/Tile.cpp src/Pin.cpp src/DigitalPin.cpp \
         src/AnalogPin.cpp src/PWMPin.cpp
 

--- a/include/AdafruitSSD1306Display.hpp
+++ b/include/AdafruitSSD1306Display.hpp
@@ -1,0 +1,19 @@
+#ifndef ADAFRUIT_SSD1306_DISPLAY_HPP
+#define ADAFRUIT_SSD1306_DISPLAY_HPP
+
+#include "Display.hpp"
+
+/**
+ * @brief Display implementation backed by the Adafruit SSD1306 library.
+ */
+class AdafruitSSD1306Display : public Display
+{
+    public:
+    explicit AdafruitSSD1306Display(Dimensions dims);
+    ~AdafruitSSD1306Display() override = default;
+
+    protected:
+    void writeBytes(Point pos, const unsigned char* data, std::size_t length) override;
+};
+
+#endif // ADAFRUIT_SSD1306_DISPLAY_HPP

--- a/include/Display.hpp
+++ b/include/Display.hpp
@@ -56,13 +56,13 @@ class Display : public Peripheral
     int getHeight() const;
 
     /**
-     * @brief Draw a sequence of bytes on the display.
+     * @brief Draw a sequence of bytes on the display and update the buffer.
      *
      * @param pos   Top-left coordinate of the data.
      * @param data  Byte array to draw.
      * @param length Number of bytes to write.
      */
-    virtual void drawBytes(Point pos, const unsigned char* data, std::size_t length) = 0;
+    virtual void drawBytes(Point pos, const unsigned char* data, std::size_t length);
 
     /**
      * @brief Create a sub-region (tile) of the display.
@@ -79,6 +79,16 @@ class Display : public Peripheral
     std::vector<Rect> tiles;
     std::vector<std::vector<unsigned char>> buffer;
     std::vector<std::vector<std::vector<unsigned char>>> stack;
+
+    /**
+     * @brief Write bytes to the physical display device.
+     *
+     * Implementations must send the given bytes to the underlying hardware.
+     * @param pos   Top-left coordinate of the data.
+     * @param data  Byte array to draw.
+     * @param length Number of bytes to write.
+     */
+    virtual void writeBytes(Point pos, const unsigned char* data, std::size_t length) = 0;
 };
 
 #endif // DISPLAY_HPP

--- a/src/AdafruitSSD1306Display.cpp
+++ b/src/AdafruitSSD1306Display.cpp
@@ -1,0 +1,32 @@
+#include "AdafruitSSD1306Display.hpp"
+
+#ifdef ARDUINO
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
+
+static Adafruit_SSD1306 oled(128, 64, &Wire);
+#endif
+
+AdafruitSSD1306Display::AdafruitSSD1306Display(Dimensions dims) : Display(dims)
+{
+#ifdef ARDUINO
+    oled.begin(SSD1306_SWITCHCAPVCC, 0x3C);
+    oled.clearDisplay();
+#endif
+}
+
+void AdafruitSSD1306Display::writeBytes(Point pos, const unsigned char* data, std::size_t length)
+{
+#ifdef ARDUINO
+    oled.setCursor(pos.x, pos.y);
+    for (std::size_t i = 0; i < length; ++i)
+    {
+        oled.write(data[i]);
+    }
+    oled.display();
+#else
+    (void) pos;
+    (void) data;
+    (void) length;
+#endif
+}

--- a/src/Display.cpp
+++ b/src/Display.cpp
@@ -10,20 +10,9 @@
 #include <vector>
 #include "Tile.hpp"
 
-#ifdef ARDUINO
-#include <Adafruit_GFX.h>
-#include <Adafruit_SSD1306.h>
-
-static Adafruit_SSD1306 oled(128, 64, &Wire);
-#endif
-
 /** Construct a display with the given dimensions. */
 Display::Display(Dimensions dims) : width(dims.width), height(dims.height)
 {
-#ifdef ARDUINO
-    oled.begin(SSD1306_SWITCHCAPVCC, 0x3C);
-    oled.clearDisplay();
-#endif
     buffer.resize(height, std::vector<unsigned char>(width, ' '));
 }
 
@@ -44,18 +33,7 @@ int Display::getHeight() const
 /** Draw raw bytes at the specified display coordinate. */
 void Display::drawBytes(Point pos, const unsigned char* data, std::size_t length)
 {
-#ifdef ARDUINO
-    oled.setCursor(pos.x, pos.y);
-    for (std::size_t i = 0; i < length; ++i)
-    {
-        oled.write(data[i]);
-    }
-    oled.display();
-#else
-    (void) pos;
-    (void) data;
-    (void) length;
-#endif
+    writeBytes(pos, data, length);
     for (std::size_t i = 0; i < length; ++i)
     {
         int x = pos.x + static_cast<int>(i);

--- a/tests/test_display.cpp
+++ b/tests/test_display.cpp
@@ -15,6 +15,14 @@ class DummyDisplay : public Display
     {
         Display::drawBytes(pos, data, length);
     }
+
+    protected:
+    void writeBytes(Point pos, const unsigned char* data, std::size_t length) override
+    {
+        (void) pos;
+        (void) data;
+        (void) length;
+    }
 };
 
 TEST_CASE("Display initializes", "[display]")
@@ -56,6 +64,14 @@ class StateDisplay : public Display
     const auto& state() const
     {
         return buffer;
+    }
+
+    protected:
+    void writeBytes(Point pos, const unsigned char* data, std::size_t length) override
+    {
+        (void) pos;
+        (void) data;
+        (void) length;
     }
 };
 

--- a/tests/test_tile.cpp
+++ b/tests/test_tile.cpp
@@ -33,6 +33,14 @@ class LoggingDisplay : public Display
     {
         return static_cast<int>(stack.size());
     }
+
+    protected:
+    void writeBytes(Point pos, const unsigned char* data, std::size_t length) override
+    {
+        (void) pos;
+        (void) data;
+        (void) length;
+    }
 };
 
 TEST_CASE("Tile dimensions", "[tile]")

--- a/tools/valgrind_main.cpp
+++ b/tools/valgrind_main.cpp
@@ -3,26 +3,36 @@
  * @brief Minimal host application used for Valgrind checks.
  */
 
+#include <vector>
 #include "AnalogPin.hpp"
 #include "DigitalPin.hpp"
 #include "Display.hpp"
 #include "Tile.hpp"
-#include <vector>
 
 class DummyDisplay : public Display
 {
-public:
-    DummyDisplay() : Display({4, 4}) {}
+    public:
+    DummyDisplay() : Display({4, 4})
+    {
+    }
     void drawBytes(Point pos, const unsigned char* data, std::size_t length) override
     {
         Display::drawBytes(pos, data, length);
     }
+
+    protected:
+    void writeBytes(Point pos, const unsigned char* data, std::size_t length) override
+    {
+        (void) pos;
+        (void) data;
+        (void) length;
+    }
 };
-#include "PWMPin.hpp"
+#include "Arduino.h"
 #include "Button.hpp"
+#include "PWMPin.hpp"
 #include "Sensor.hpp"
 #include "Switch.hpp"
-#include "Arduino.h"
 
 int main()
 {


### PR DESCRIPTION
## Summary
- decouple Display from Adafruit implementation via abstract writeBytes
- add AdafruitSSD1306Display subclass for hardware-specific behavior
- adjust tests and build to support new display class

## Testing
- `make precommit` *(fails: HTTPClientError during PlatformIO platform installation)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6898f818dbfc832da9ff2ea2f933796a